### PR TITLE
Sweeping changes

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,4 +3,8 @@ coverage:
         project:
             default:
                 # Basic threshold for your project
-                target: 97% # testing if this does anything
+                target: 85%
+        patch:
+            default:
+                # Target coverage for the changes in pull requests
+                target: 80%

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,6 +19,6 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install black isort
 
-            - name: Check Formatting
+            - name: Check code style
               run: |
-                  make check-format
+                  make check-style

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: "3.8" # Update as per your project's Python version
+                  python-version: "3.10" # Update as per your project's Python version
 
             - name: Install Dependencies
               run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,24 @@
+name: Code Style Check
+
+on: [push, pull_request]
+
+jobs:
+    style:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: "3.8" # Update as per your project's Python version
+
+            - name: Install Dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install black isort
+
+            - name: Check Formatting
+              run: |
+                  make check-format

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: style check-style
+
+style:
+	@echo "Running isort..."
+	isort src/ tests/
+	@echo "Running black..."
+	black src/ tests/
+
+check-style:
+	@echo "Checking isort..."
+	isort --check-only src/ tests/
+	@echo "Checking black..."
+	black --check src/ tests/

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 
 style:
 	@echo "Running isort..."
-	isort src/ tests/
+	isort src
 	@echo "Running black..."
-	black src/ tests/
+	black src
 
 check-style:
 	@echo "Checking isort..."
-	isort --check-only src/ tests/
+	isort --check-only src
 	@echo "Checking black..."
-	black --check src/ tests/
+	black --check src

--- a/README.md
+++ b/README.md
@@ -37,3 +37,25 @@ Note: we don't support floats right now so please use fractions!
 ## Please make issues!
 
 This project is actively undergoing development; please let me know about any bugs you encounter by making a github issue! If there's an integral that we currently can't solve, create an issue and tag "new integral."
+
+# Code style
+
+This project uses black and isort with line width of 120.
+
+Run `make style` to format accordingly. And `make check-style` to check your edits meet the formatting guidelines.
+
+If you use vscode, you can add this to `settings.json` to automatically format when you save.
+
+```
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "always",
+            "source.fixAll": "always"
+        },
+        "editor.rulers": [120],
+    },
+    "black-formatter.args": ["--line-length", "120"],
+    "isort.args": ["--profile", "black", "--line-length", "120"],
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120

--- a/src/simpy/__init__.py
+++ b/src/simpy/__init__.py
@@ -1,3 +1,19 @@
-from .expr import (acos, asin, atan, cos, cot, csc, debug_repr, diff, e, log,
-                   pi, sec, sin, sqrt, symbols, tan)
+from .expr import (
+    acos,
+    asin,
+    atan,
+    cos,
+    cot,
+    csc,
+    debug_repr,
+    diff,
+    e,
+    log,
+    pi,
+    sec,
+    sin,
+    sqrt,
+    symbols,
+    tan,
+)
 from .integration import integrate

--- a/src/simpy/__init__.py
+++ b/src/simpy/__init__.py
@@ -1,19 +1,2 @@
-from .expr import (
-    acos,
-    asin,
-    atan,
-    cos,
-    cot,
-    csc,
-    debug_repr,
-    diff,
-    e,
-    log,
-    pi,
-    sec,
-    sin,
-    sqrt,
-    symbols,
-    tan,
-)
+from .expr import acos, asin, atan, cos, cot, csc, debug_repr, diff, e, log, pi, sec, sin, sqrt, symbols, tan
 from .integration import integrate

--- a/src/simpy/combinatorics.py
+++ b/src/simpy/combinatorics.py
@@ -5,7 +5,7 @@ from typing import List
 
 def generate_permutations(i: int, n: int) -> List[List[int]]:
     """
-    generate all permutations of i numbers x_i that sum up to n, where 0<=x_i<=n 
+    generate all permutations of i numbers x_i that sum up to n, where 0<=x_i<=n
 
     i: number of terms
     n: sum of terms
@@ -13,12 +13,13 @@ def generate_permutations(i: int, n: int) -> List[List[int]]:
     This function uses a recursive approach to explore each possible value for x_i from 0 to
     n, and then recursively calls itself to handle the remaining numbers and the reduced sum
     """
+
     def generate(current_permutation: List[int], current_sum: int, remaining_numbers: int):
         if remaining_numbers == 0:
             if current_sum == n:
                 results.append(current_permutation[:])
             return
-        
+
         start = 0
         end = min(n, n - current_sum)  # Maximum value that can be added without exceeding the sum n
         for value in range(start, end + 1):
@@ -30,13 +31,14 @@ def generate_permutations(i: int, n: int) -> List[List[int]]:
     generate([], 0, i)
     return results
 
+
 def multinomial_coefficient(xs: List[int], n: int) -> int:
     if sum(xs) > n:
         return "Invalid input: sum of xs must not exceed n."
-    
+
     # Calculate factorial of n and the individual components x1, x2 ..., and the remaining items
     numerator = math.factorial(n)
-    
+
     # now, calculate the denominator
     mul = lambda x, y: x * y
     add = lambda x, y: x + y
@@ -44,5 +46,5 @@ def multinomial_coefficient(xs: List[int], n: int) -> int:
     xs_factorials_product = functools.reduce(mul, xs_factorials)
     xs_sum = functools.reduce(add, xs)
     denominator = math.factorial(n - xs_sum) * xs_factorials_product
-    
+
     return numerator // denominator  # Integer division for exact result

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -889,7 +889,7 @@ def deconstruct_power(expr: Expr) -> Tuple[Expr, Rat]:
 
 isfractionorneg = lambda x: isinstance(x, Rat) and (x.value.denominator != 1 or x < 0)
 islongsymbol = (
-    lambda x: isinstance(x, Symbol) and len(x.name) > 1 or x.__class__.__name__ == "Any_" and len(x.anykey) > 1
+    lambda x: isinstance(x, Symbol) and len(x.name) > 1 or x.__class__.__name__ == "Any_" and len(x.key) > 1
 )
 
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1014,7 +1014,7 @@ class Power(Expr):
             else:
                 return -Power(-b, x)
         # not fully exhaustive.
-        if (isinstance(b, Number) or isinstance(b, Prod) and all(isinstance(t, Number) for t in terms)) and not b.is_subtraction:
+        if (isinstance(b, Number) or isinstance(b, Prod) and all(isinstance(t, Number) for t in b.terms)) and not b.is_subtraction:
             if x == oo:
                 return oo
             if x == -oo:
@@ -1075,7 +1075,8 @@ class Power(Expr):
     
     @property
     def is_subtraction(self) -> bool:
-        return self.base.is_subtraction
+        # not exhaustive properly idk
+        return self.base.is_subtraction and len(self.symbols()) == 0
 
 
 @dataclass
@@ -1168,10 +1169,12 @@ class log(SingleFunc):
             return -1 * log(inner.reciprocal_class(inner.inner)).simplify()
         
         # ugly patch lmfao. need better overall philosophy for this stuff.
+        if isinstance(inner, Abs) and isinstance(inner.inner, Power):
+            return (log(abs(inner.inner.base)) * inner.inner.exponent).simplify()
         if isinstance(inner, Abs) and isinstance(inner.inner, Prod):
-            return Sum([log(abs(term)) for term in inner.inner.terms])
+            return Sum([log(abs(term)) for term in inner.inner.terms]).simplify()
         if isinstance(inner, Abs) and isinstance(inner.inner, Sum) and isinstance(inner.inner.factor(), Prod):
-            return Sum([log(abs(term)) for term in inner.inner.factor().terms])
+            return Sum([log(abs(term)) for term in inner.inner.factor().terms]).simplify()
 
         return log(inner)
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -936,9 +936,9 @@ class Power(Expr):
     exponent: Expr
 
     def __repr__(self) -> str:
-        isfraction = lambda x: isinstance(x, Const) and x.value.denominator != 1
+        isfractionorneg = lambda x: isinstance(x, Const) and (x.value.denominator != 1 or x < 0)
         def _term_repr(term):
-            if isinstance(term, Sum) or isinstance(term, Prod) or isfraction(term):
+            if isinstance(term, Sum) or isinstance(term, Prod) or isfractionorneg(term):
                 return "(" + repr(term) + ")"
             return repr(term)
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -369,8 +369,6 @@ class Num(ABC):
 
 def Const(value: Union[float, Fraction, int]) -> Num:
     # wrapper ??
-    if isinstance(value, (int, Fraction)) or int(value) == value:
-        return Rat(value)
 
     if value == float('inf'):
         return Infinity()
@@ -378,6 +376,9 @@ def Const(value: Union[float, Fraction, int]) -> Num:
         return NegInfinity()
     if value == float('NaN'):
         return NaN()
+    if isinstance(value, (int, Fraction)) or int(value) == value:
+        return Rat(value)
+
     return Float(value)
 
 class Float(Num, Expr):
@@ -601,6 +602,13 @@ def _accumulate_power(b: Accumulateable, x: Accumulateable) -> Optional[Expr]:
     
     if isinstance(b, (Infinity, NegInfinity)) or isinstance(x, (Infinity, NegInfinity)):
         return Const(b.value ** x.value)
+
+    if b == 0:
+        if x > 0:
+            return Rat(0)
+        else:
+            # Division by zero.
+            return inf
 
     if isinstance(b, Rat) and isinstance(x, Rat):
         try:
@@ -1137,8 +1145,6 @@ class Power(Expr):
             return Rat(1)
         if x == 1:
             return b
-        if b == 0:
-            return Rat(0)
         if b == 1:
             return Rat(1)
         if isinstance(b, Accumulateable) and isinstance(x, Accumulateable):

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -603,8 +603,8 @@ class Sum(Associative, Expr):
         for i, term in enumerate(self.terms):
             if i == 0:
                 ongoing_str += f"{term}"
-            elif isinstance(term, Prod) and term.is_subtraction:
-                ongoing_str += f" - {(term * -1)}"
+            elif term.is_subtraction:
+                ongoing_str += f" - {term * -1}"
             else:
                 ongoing_str += f" + {term}"
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1033,7 +1033,18 @@ class Power(Expr):
         self.__post_init__()
     
     def simplify(self) -> "Expr":
-        return Power(self.base.simplify(), self.exponent.simplify())
+        # in the LR this shouldnt be in simplify necessarily; i see the point of sympy having diff
+        # functions for simplify. like, after rewritetrig you can't apply this one but you can apply
+        # other simplifies. idk.
+        
+        # or just in general during integration it's not useful to apply this simplify; it's only
+        # useful for simplifying the expression for the user to see & for subtractions.
+        b = self.base.simplify()
+        x = self.exponent.simplify()
+        if isinstance(x, Const) and x < 0 and isinstance(b, TrigFunction) and not b.is_inverse:
+            new_b = b.reciprocal_class(b.inner)
+            return Power(new_b, -x).simplify()
+        return Power(b, x) 
     
     def _power_expandable(self) -> bool:
         return (

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -896,6 +896,9 @@ def deconstruct_power(expr: Expr) -> Tuple[Expr, Rat]:
     else:
         return (expr, Rat(1))
 
+isfractionorneg = lambda x: isinstance(x, Rat) and (x.value.denominator != 1 or x < 0)
+islongsymbol = lambda x: isinstance(x, Symbol) and len(x.name) > 1 or x.__class__.__name__ == "Any_" and len(x.anykey) > 1
+
 
 @dataclass
 class Prod(Associative, Expr):
@@ -960,7 +963,7 @@ class Prod(Associative, Expr):
 
     def __repr__(self) -> str:
         def _term_repr(term):
-            if isinstance(term, Sum):
+            if isinstance(term, Sum) or islongsymbol(term):
                 return "(" + repr(term) + ")"
             return repr(term)
 
@@ -1084,6 +1087,7 @@ class Prod(Associative, Expr):
         )
 
 
+
 def debug_repr(expr: Expr) -> str:
     """Not designed to look pretty; designed to show the structure of the expr.
     """
@@ -1106,9 +1110,8 @@ class Power(Expr):
     exponent: Expr
 
     def __repr__(self) -> str:
-        isfractionorneg = lambda x: isinstance(x, Rat) and (x.value.denominator != 1 or x < 0)
         def _term_repr(term):
-            if isinstance(term, Sum) or isinstance(term, Prod) or isfractionorneg(term):
+            if isinstance(term, Sum) or isinstance(term, Prod) or isfractionorneg(term) or islongsymbol(term):
                 return "(" + repr(term) + ")"
             return repr(term)
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -91,6 +91,7 @@ def cast(func):
 
 
 class Expr(ABC):
+    """Base class for all expressions."""
     def __post_init__(self):
         # if any field is an Expr, cast it
         for field in fields(self):
@@ -688,6 +689,7 @@ class Symbol(Expr):
 
 @dataclass
 class Sum(Associative, Expr):
+    """A sum expression."""
     @cast
     def __new__(cls, terms: List[Expr]) -> "Expr":
         """When a sum is initiated:
@@ -785,10 +787,12 @@ class Sum(Associative, Expr):
         return ongoing_str
 
     def factor(self) -> Union["Prod", "Sum"]:
+        """
+        This method currently does:
+        - If there is a factor that is common to all terms, factor it out.
+        - If there is a factor that is common to some terms, let's just ignore it.
+        """
         # TODO: this feels like not the most efficient algo
-        # assume self is simplified please
-        # If there is a factor that is common to all terms, factor it out.
-        # If there is a factor that is common to some terms, let's just ignore it.
         # TODO: doesn't factor ex. quadratics into 2 binomials. implement some form of multi-term polynomial factoring at some point
         # (needed for partial fractions)
 
@@ -888,6 +892,7 @@ islongsymbol = (
 
 @dataclass
 class Prod(Associative, Expr):
+    """A product expression."""
     @cast
     def __new__(cls, terms: List[Expr]) -> "Expr":
         # We need to flatten BEFORE we accumulate like terms

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -43,6 +43,8 @@ def nesting(expr: "Expr", var: Optional["Symbol"] = None) -> int:
     # special case
     if isinstance(expr, Prod) and expr.terms[0] == Const(-1) and len(expr.terms) == 2:
         return nesting(expr.terms[1], var)
+    if isinstance(expr, Prod):
+        return 1 + max(_nesting(sub_expr, var) for sub_expr in expr.children())
 
     if isinstance(expr, Symbol) and (var is None or expr.name == var.name):
         return 1
@@ -51,6 +53,11 @@ def nesting(expr: "Expr", var: Optional["Symbol"] = None) -> int:
     else:
         return 1 + max(nesting(sub_expr, var) for sub_expr in expr.children())
 
+
+def _nesting(e, v) -> int:
+    if isinstance(e, Power) and e.exponent == -1:
+        return nesting(e.base, v)
+    return nesting(e, v)
 
 
 def _cast(x):

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -437,11 +437,15 @@ class Infinity(Number, Expr):
 
     def latex(self) -> str:
         return "\\infty"
+    
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Infinity)
 
 
 pi = Pi()
 e = E()
-infinity = Infinity() # This isn't used for anything yet.
+oo = Infinity() # should division by zero be inf or be zero divisionerror or? // sympy makes it zoo
+# not gonna export this yet bc it's expiremental?
 
 
 @dataclass
@@ -1009,6 +1013,12 @@ class Power(Expr):
                 return Power(-b, x)
             else:
                 return -Power(-b, x)
+        # not fully exhaustive.
+        if (isinstance(b, Number) or isinstance(b, Prod) and all(isinstance(t, Number) for t in terms)) and not b.is_subtraction:
+            if x == oo:
+                return oo
+            if x == -oo:
+                return Const(0)
 
         return default_return
     

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -180,7 +180,7 @@ class Expr(ABC):
     def expandable(self) -> bool:
         if not self.children():
             return False
-        return any([c.expandable() for c in self.children()])
+        return any(c.expandable() for c in self.children())
 
     # overload if necessary
     def expand(self) -> "Expr":
@@ -906,7 +906,7 @@ class Sum(Associative, Expr):
 
     @property
     def is_subtraction(self):
-        return all([t.is_subtraction for t in self.terms])
+        return all(t.is_subtraction for t in self.terms)
 
 
 def _deconstruct_prod(expr: Expr) -> Tuple[Rat, List[Expr]]:

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1156,6 +1156,12 @@ class log(SingleFunc):
         # i dont love this, can change
         if isinstance(inner, (sec, csc, cot)):
             return -1 * log(inner.reciprocal_class(inner.inner)).simplify()
+        
+        # ugly patch lmfao. need better overall philosophy for this stuff.
+        if isinstance(inner, Abs) and isinstance(inner.inner, Prod):
+            return Sum([log(abs(term)) for term in inner.inner.terms])
+        if isinstance(inner, Abs) and isinstance(inner.inner, Sum) and isinstance(inner.inner.factor(), Prod):
+            return Sum([log(abs(term)) for term in inner.inner.factor().terms])
 
         return log(inner)
 
@@ -1475,6 +1481,10 @@ class Abs(SingleFunc):
             return inner.abs()
         if inner.is_subtraction:
             return Abs(-inner)
+        if isinstance(inner, Prod):
+            for t in inner.terms:
+                if isinstance(inner, Const):
+                    return Abs(inner/t) * Abs(t)
         return super().__new__(cls)
     
     def diff(self, var) -> Expr:

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1438,6 +1438,8 @@ TrigStr = Literal["sin", "cos", "tan", "sec", "csc", "cot"]
 
 
 class TrigFunction(SingleFunc, ABC):
+    is_inverse: bool = False  # class property
+
     _SPECIAL_KEYS = [
         "0",
         "1/6",
@@ -1460,11 +1462,6 @@ class TrigFunction(SingleFunc, ABC):
     @abstractmethod
     @classproperty
     def func(cls) -> TrigStr:
-        pass
-
-    @abstractmethod
-    @classproperty
-    def is_inverse(cls) -> bool:
         pass
 
     @staticproperty

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -867,7 +867,7 @@ class Prod(Associative, Expr):
 
     @property
     def is_subtraction(self):
-        return isinstance(self.terms[0], Const) and self.terms[0].value < 0
+        return isinstance(self.terms[0], Const) and self.terms[0] < 0
 
     @cast
     def expandable(self) -> bool:
@@ -917,7 +917,6 @@ class Prod(Associative, Expr):
                 for e in self.terms
             ]
         )
-
 
 
 def debug_repr(expr: Expr) -> str:

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1703,6 +1703,7 @@ class Abs(SingleFunc):
 
 
 def symbols(symbols: str) -> Union[Symbol, List[Symbol]]:
+    """Creates symbols from a string of symbol names seperated by spaces."""
     symbols = [Symbol(name=s) for s in symbols.split(" ")]
     return symbols if len(symbols) > 1 else symbols[0]
 

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -1458,6 +1458,7 @@ class TrigFunction(SingleFunc, ABC):
         "7/4",
         "11/6",
     ]
+    _special_values_cache = None
 
     @abstractmethod
     @classproperty
@@ -1494,8 +1495,14 @@ class TrigFunction(SingleFunc, ABC):
 
     @classproperty
     @abstractmethod
-    def special_values(cls) -> Dict[str, Expr]:
+    def _special_values(cls) -> Dict[str, Expr]:
         pass
+
+    @classproperty
+    def special_values(cls) -> Dict[str, Expr]:
+        if cls._special_values_cache is None:
+            cls._special_values_cache = cls._special_values
+        return cls._special_values_cache
 
     @classproperty
     @abstractmethod
@@ -1574,7 +1581,7 @@ class sin(TrigFunction):
         return csc
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {
             "0": Rat(0),
             "1/6": Rat(1, 2),
@@ -1613,7 +1620,7 @@ class cos(TrigFunction):
         return sec
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {
             "0": Rat(1),
             "1/6": sqrt(3) / 2,
@@ -1667,7 +1674,7 @@ class tan(TrigFunction):
         return super().__new__(cls, inner)
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {k: sin.special_values[k] / cos.special_values[k] for k in cls._SPECIAL_KEYS}
 
     def diff(self, var) -> Expr:
@@ -1680,7 +1687,7 @@ class csc(TrigFunction):
     reciprocal_class = sin
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {k: 1 / sin.special_values[k] for k in cls._SPECIAL_KEYS}
 
     def diff(self, var) -> Expr:
@@ -1693,7 +1700,7 @@ class sec(TrigFunction):
     reciprocal_class = cos
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {k: 1 / cos.special_values[k] for k in cls._SPECIAL_KEYS}
 
     def diff(self, var) -> Expr:
@@ -1706,7 +1713,7 @@ class cot(TrigFunction):
     _func = lambda x: 1 / math.tan(x)
 
     @classproperty
-    def special_values(cls):
+    def _special_values(cls):
         return {k: cos.special_values[k] / sin.special_values[k] for k in cls._SPECIAL_KEYS}
 
     def diff(self, var) -> Expr:

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -888,9 +888,7 @@ def deconstruct_power(expr: Expr) -> Tuple[Expr, Rat]:
 
 
 isfractionorneg = lambda x: isinstance(x, Rat) and (x.value.denominator != 1 or x < 0)
-islongsymbol = (
-    lambda x: isinstance(x, Symbol) and len(x.name) > 1 or x.__class__.__name__ == "Any_" and len(x.key) > 1
-)
+islongsymbol = lambda x: isinstance(x, Symbol) and len(x.name) > 1 or x.__class__.__name__ == "Any_" and len(x.key) > 1
 
 
 @dataclass

--- a/src/simpy/expr.py
+++ b/src/simpy/expr.py
@@ -493,6 +493,30 @@ class Rat(Num, Expr):
             return Rat(other.value - self.value)
         return super().__rsub__(other)
 
+    @cast
+    def __mul__(self, other) -> "Expr":
+        if isinstance(other, Rat):
+            return Rat(self.value * other.value)
+        return super().__mul__(other)
+
+    @cast
+    def __rmul__(self, other) -> "Expr":
+        if isinstance(other, Rat):
+            return Rat(other.value * self.value)
+        return super().__rmul__(other)
+
+    @cast
+    def __truediv__(self, other) -> "Expr":
+        if isinstance(other, Rat) and other.value != 0:
+            return Rat(self.value / other.value)
+        return super().__truediv__(other)
+
+    @cast
+    def __rtruediv__(self, other) -> "Expr":
+        if isinstance(other, Rat) and self.value != 0:
+            return Rat(other.value / self.value)
+        return super().__rtruediv__(other)
+
     def __neg__(self):
         return Rat(-self.value)
 

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -207,13 +207,7 @@ class Integration:
 
         if nesting(ans.expr) >= self.DEPTH_FIRST_MAX_NESTING:
             return True
-        from .transforms import (
-            Additivity,
-            ByParts,
-            Expand,
-            PullConstant,
-            _get_last_heuristic_transform,
-        )
+        from .transforms import Additivity, ByParts, Expand, PullConstant, _get_last_heuristic_transform
 
         t = _get_last_heuristic_transform(ans, (Expand, PullConstant, Additivity))
         if isinstance(t, ByParts):

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -6,7 +6,7 @@ import warnings
 from collections import defaultdict
 from typing import Callable, Dict, List, Literal, Tuple, Union
 
-from .expr import Const, Expr, Optional, Symbol, cast, nesting
+from .expr import Expr, Optional, Rat, Symbol, cast, nesting
 from .regex import replace, replace_factory
 from .transforms import HEURISTICS, SAFE_TRANSFORMS, Node, _check_if_solveable
 

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -29,7 +29,7 @@ def _get_best_leaf(root: Node) -> Node:
     if len(root.unfinished_children) == 0:
         return root  # base case ???
 
-    is_2nd_lowest_parent = all([not child.unfinished_children for child in root.unfinished_children])
+    is_2nd_lowest_parent = all(not child.unfinished_children for child in root.unfinished_children)
     fn = min if root.type == "OR" else max
     if is_2nd_lowest_parent:
         return _get_node_with_best_nesting(root.unfinished_children, fn)

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -123,7 +123,7 @@ class Integration:
         integral = self.integrate(expr, bounds[0])
         if integral is None:
             return None
-        return (integral.evalf({x.name: b}) - integral.evalf({x.name: a})).simplify()
+        return (integral.subs({x.name: b}) - integral.subs({x.name: a})).simplify()
     
     @staticmethod
     def integrate_without_heuristics(integrand: Expr, var: Symbol) -> Optional[Expr]:

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -131,7 +131,10 @@ class Integration:
         if root.is_failed:
             return None
         Integration._go_backwards(root)
-        return root.solution.simplify()
+
+        # Unsure if not simplifying here could cause problems down the line
+        # but it seems to work fine for now.
+        return root.solution
 
     def _cycle(self, node: Node) -> Optional[Union[Node, Literal["SOLVED"]]]:
         # 1. APPLY ALL SAFE TRANSFORMS

--- a/src/simpy/integration.py
+++ b/src/simpy/integration.py
@@ -59,11 +59,11 @@ def integrate(
         bounds: (var, a, b) where var is the variable of integration and a, b are the integration bounds.
             can omit var if integrand contains exactly one symbol. omit a, b for an indefinite integral.
     kwargs:
-        verbose: prints the integration tree + enables the python debugger right before returning.
+        debug: prints the integration tree + enables the python debugger right before returning.
             you can use the python debugger to trace back the integration tree & find out what went wrong.
             if you don't know what this means, don't worry about it -- this is mostly for developers and
             particularly nerdy adventurers.
-        debug
+        debug_hardcore
         breadth_first
 
         Examples of valid uses:
@@ -103,9 +103,9 @@ class Integration:
     Keeps track of integration work as we go
     """
 
-    def __init__(self, *, verbose: bool = False, debug: bool = False, breadth_first = True):
-        self._verbose = verbose
+    def __init__(self, *, debug: bool = False, debug_hardcore: bool = False, breadth_first = True):
         self._debug = debug
+        self._debug_hardcore = debug_hardcore
         self._breadth_first = breadth_first
         self._timeout = 2 # seconds
     
@@ -169,10 +169,10 @@ class Integration:
                 return None
             return "SOLVED"
         
-        if len(node.unfinished_leaves) == 1:
-            return node.unfinished_leaves[0]
+        if len(root.unfinished_leaves) == 1:
+            return root.unfinished_leaves[0]
         
-        return _get_best_leaf(node)
+        return _get_best_leaf(root)
     
     def _get_next_node_post_heuristic_depth_first(self, node: Node) -> Node:
         if len(node.unfinished_leaves) == 0:
@@ -229,7 +229,7 @@ class Integration:
             if not root.is_failed:
                 message += ", TIMED OUT"
             warnings.warn(message)
-            if self._verbose:
+            if self._debug:
                 _print_tree(root)
                 breakpoint()
             return None
@@ -237,7 +237,7 @@ class Integration:
         # now we have a solved tree we can go back and get the answer
         self._go_backwards(root)
 
-        if self._verbose:
+        if self._debug:
             _print_success_tree(root)
             breakpoint()
         return root.solution.simplify()

--- a/src/simpy/linalg.py
+++ b/src/simpy/linalg.py
@@ -9,13 +9,13 @@ def invert(matrix: np.ndarray):
     assert len(matrix.shape) == 2 and matrix.shape[0] == matrix.shape[1]
     n = matrix.shape[0]
     if n != 2:
-        raise NotImplementedError("Only 2x2 matrices are supported. There's no need to expand this until I allow partial fractions for trinomials.+")
-    
+        raise NotImplementedError(
+            "Only 2x2 matrices are supported. There's no need to expand this until I allow partial fractions for trinomials.+"
+        )
+
     a, b, c, d = matrix[0, 0], matrix[0, 1], matrix[1, 0], matrix[1, 1]
     det = (a * d - b * c).simplify()
     if det == 0:
         return None
 
     return np.array([[d / det, -b / det], [-c / det, a / det]])
-
-

--- a/src/simpy/linalg.py
+++ b/src/simpy/linalg.py
@@ -14,7 +14,7 @@ def invert(matrix: np.ndarray):
         )
 
     a, b, c, d = matrix[0, 0], matrix[0, 1], matrix[1, 0], matrix[1, 1]
-    det = (a * d - b * c).simplify()
+    det = a * d - b * c
     if det == 0:
         return None
 

--- a/src/simpy/polynomial.py
+++ b/src/simpy/polynomial.py
@@ -18,9 +18,7 @@ def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, mult
         answer: List[Rat] = []
 
     def _add_answer(const: Rat, idx: int, answer: List[Rat] = answer, multiplier: Rat = multiplier):
-        new_const = (
-            const * multiplier
-        ).simplify()  # you really shouldn't need simplify here. combine like terms should happen in init.
+        new_const = const * multiplier
         if idx < len(answer):
             answer[idx] += new_const
         elif idx == len(answer):
@@ -68,11 +66,10 @@ def polynomial_to_expr(poly: Polynomial, var: Symbol) -> Expr:
     final = Rat(0)
     for i, element in enumerate(poly):
         final += element * var**i
-    return final.simplify()
+    return final
 
 
-def rid_ending_zeros(arr: Polynomial) -> Polynomial:
-    lis = [el.simplify() for el in arr]
+def rid_ending_zeros(lis: Polynomial) -> Polynomial:
     num_zeros = 0
     for i in reversed(range(len(lis))):
         if lis[i] == 0:

--- a/src/simpy/polynomial.py
+++ b/src/simpy/polynomial.py
@@ -4,6 +4,7 @@ from .expr import *
 
 Polynomial = np.ndarray  # has to be 1-D array
 
+
 def is_polynomial(expr: Expr, var: Symbol) -> bool:
     try:
         to_const_polynomial(expr, var)
@@ -11,12 +12,15 @@ def is_polynomial(expr: Expr, var: Symbol) -> bool:
     except AssertionError:
         return False
 
-def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, multiplier:Rat=Rat(1)) -> List[Rat]:
+
+def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, multiplier: Rat = Rat(1)) -> List[Rat]:
     if answer is None:
         answer: List[Rat] = []
-    
-    def _add_answer(const: Rat, idx: int, answer: List[Rat]=answer, multiplier: Rat=multiplier):
-        new_const = (const * multiplier).simplify() # you really shouldn't need simplify here. combine like terms should happen in init.
+
+    def _add_answer(const: Rat, idx: int, answer: List[Rat] = answer, multiplier: Rat = multiplier):
+        new_const = (
+            const * multiplier
+        ).simplify()  # you really shouldn't need simplify here. combine like terms should happen in init.
         if idx < len(answer):
             answer[idx] += new_const
         elif idx == len(answer):
@@ -25,7 +29,6 @@ def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, mult
             answer += [Rat(0)] * (idx - len(answer))
             answer.append(new_const)
 
-    
     if not expr.contains(var):
         _add_answer(expr, 0)
 
@@ -41,16 +44,20 @@ def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, mult
         _to_const_polynomial(other, var, answer, multiplier=const)
     elif isinstance(expr, Power):
         assert expr.base == var
-        assert isinstance(expr.exponent, Rat) and expr.exponent.value == int(expr.exponent.value) and expr.exponent.value >= 1
+        assert (
+            isinstance(expr.exponent, Rat)
+            and expr.exponent.value == int(expr.exponent.value)
+            and expr.exponent.value >= 1
+        )
         _add_answer(1, int(expr.exponent.value))
     elif isinstance(expr, Symbol):
         assert expr == var
         _add_answer(Rat(1), 1)
     else:
         raise AssertionError(f"Not allowed expr for polynomial: {expr}")
-    
+
     return answer
-        
+
 
 def to_const_polynomial(expr: Expr, var: Symbol) -> Polynomial:
     expr = expr.expand() if expr.expandable() else expr
@@ -72,5 +79,5 @@ def rid_ending_zeros(arr: Polynomial) -> Polynomial:
             num_zeros += 1
         else:
             break
-    new_list = lis[:len(lis) - num_zeros]
+    new_list = lis[: len(lis) - num_zeros]
     return np.array(new_list)

--- a/src/simpy/polynomial.py
+++ b/src/simpy/polynomial.py
@@ -11,18 +11,18 @@ def is_polynomial(expr: Expr, var: Symbol) -> bool:
     except AssertionError:
         return False
 
-def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Const] = None, multiplier:Const=Const(1)) -> List[Const]:
+def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Rat] = None, multiplier:Rat=Rat(1)) -> List[Rat]:
     if answer is None:
-        answer: List[Const] = []
+        answer: List[Rat] = []
     
-    def _add_answer(const: Const, idx: int, answer: List[Const]=answer, multiplier: Const=multiplier):
+    def _add_answer(const: Rat, idx: int, answer: List[Rat]=answer, multiplier: Rat=multiplier):
         new_const = (const * multiplier).simplify() # you really shouldn't need simplify here. combine like terms should happen in init.
         if idx < len(answer):
             answer[idx] += new_const
         elif idx == len(answer):
             answer.append(new_const)
         else:
-            answer += [Const(0)] * (idx - len(answer))
+            answer += [Rat(0)] * (idx - len(answer))
             answer.append(new_const)
 
     
@@ -37,15 +37,15 @@ def _to_const_polynomial(expr: Expr, var: Symbol, answer: List[Const] = None, mu
         # has to be product of 2 terms: a constant and a power.
         assert len(expr.terms) == 2
         const, other = expr.terms
-        assert isinstance(const, Const)
+        assert isinstance(const, Rat)
         _to_const_polynomial(other, var, answer, multiplier=const)
     elif isinstance(expr, Power):
         assert expr.base == var
-        assert isinstance(expr.exponent, Const) and expr.exponent.value == int(expr.exponent.value) and expr.exponent.value >= 1
+        assert isinstance(expr.exponent, Rat) and expr.exponent.value == int(expr.exponent.value) and expr.exponent.value >= 1
         _add_answer(1, int(expr.exponent.value))
     elif isinstance(expr, Symbol):
         assert expr == var
-        _add_answer(Const(1), 1)
+        _add_answer(Rat(1), 1)
     else:
         raise AssertionError(f"Not allowed expr for polynomial: {expr}")
     
@@ -58,7 +58,7 @@ def to_const_polynomial(expr: Expr, var: Symbol) -> Polynomial:
 
 
 def polynomial_to_expr(poly: Polynomial, var: Symbol) -> Expr:
-    final = Const(0)
+    final = Rat(0)
     for i, element in enumerate(poly):
         final += element * var**i
     return final.simplify()

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -37,7 +37,10 @@ class Any_(Expr):
         return "(any_" + self.anykey + ")"
     
     # implementing some Expr abstract methods
-    def evalf(self, subs: Dict[str, "Rat"]):
+    def subs(self, subs: Dict[str, "Rat"]):
+        raise NotImplementedError(f"Cannot evaluate {self}")
+    
+    def _evalf(self, subs):
         raise NotImplementedError(f"Cannot evaluate {self}")
     
     def children(self) -> List["Expr"]:
@@ -59,30 +62,30 @@ any_ = Any_()
 def eq(expr: Expr, query: Expr, up_to_factor = False, up_to_sum=False):
     return Eq(expr, query, up_to_factor, up_to_sum=up_to_sum)()
 
-@dataclass
-class Inverse(Expr):
-    inner: Expr # = 1
+# @dataclass
+# class Inverse(Expr):
+#     inner: Expr # = 1
 
-    def __eq__(self, other):
-        return isinstance(other, Inverse) and other.inner == self.inner
+#     def __eq__(self, other):
+#         return isinstance(other, Inverse) and other.inner == self.inner
     
-    def __repr__(self) -> str:
-        return f"Inverse({self.inner})"
+#     def __repr__(self) -> str:
+#         return f"Inverse({self.inner})"
 
-    # implementing some Expr abstract methods
-    def evalf(self, subs: Dict[str, "Rat"]):
-        raise NotImplementedError(f"Cannot evaluate {self}")
+#     # implementing some Expr abstract methods
+#     def subs(self, subs: Dict[str, "Rat"]):
+#         raise NotImplementedError(f"Cannot evaluate {self}")
     
-    def children(self) -> List["Expr"]:
-        return self.inner
+#     def children(self) -> List["Expr"]:
+#         return self.inner
 
-    def diff(self, var: "Symbol") -> "Expr":
-        raise NotImplementedError(
-            f"Cannot get the derivative of {self.__class__.__name__}"
-        )
+#     def diff(self, var: "Symbol") -> "Expr":
+#         raise NotImplementedError(
+#             f"Cannot get the derivative of {self.__class__.__name__}"
+#         )
 
-    def latex(self) -> str:
-        raise NotImplementedError(f"Cannot convert {self.__class__.__name__} to latex")
+#     def latex(self) -> str:
+#         raise NotImplementedError(f"Cannot convert {self.__class__.__name__} to latex")
 
 
 def get_anys(expr: Expr) -> List[Any_]:

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -370,6 +370,12 @@ def general_count(expr: Expr, condition: Callable[[Expr], bool]) -> int:
     return sum(general_count(e, condition) for e in expr.children())
 
 
+def general_contains(expr: Expr, condition: Callable[[Expr], bool]) -> bool:
+    if condition(expr):
+        return True
+    return any(general_contains(e, condition) for e in expr.children())
+
+
 def replace_factory(condition, perform) -> ExprFn:
     return replace_factory_list([condition], [perform])
 
@@ -433,7 +439,6 @@ def kinder_replace_many(expr: Expr, performs: Iterable[OptionalExprFn], verbose=
                 is_hit["hi"] = True
                 return new
 
-        # find all instances of old in expr and replace with new
         if isinstance(e, Sum):
             return Sum([_replace(t) for t in e.terms])
         if isinstance(e, Prod):

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Type
 
-from .expr import Const, Expr, Power, Prod, SingleFunc, Sum, Symbol, cast
+from .expr import Expr, Power, Prod, Rat, SingleFunc, Sum, Symbol, cast
 from .utils import ExprFn, OptionalExprFn, random_id
 
 
@@ -37,7 +37,7 @@ class Any_(Expr):
         return "(any_" + self.anykey + ")"
     
     # implementing some Expr abstract methods
-    def evalf(self, subs: Dict[str, "Const"]):
+    def evalf(self, subs: Dict[str, "Rat"]):
         raise NotImplementedError(f"Cannot evaluate {self}")
     
     def children(self) -> List["Expr"]:
@@ -70,7 +70,7 @@ class Inverse(Expr):
         return f"Inverse({self.inner})"
 
     # implementing some Expr abstract methods
-    def evalf(self, subs: Dict[str, "Const"]):
+    def evalf(self, subs: Dict[str, "Rat"]):
         raise NotImplementedError(f"Cannot evaluate {self}")
     
     def children(self) -> List["Expr"]:
@@ -241,7 +241,7 @@ class Eq:
             # You don't get to divide if we already is --- prevents inf recursion.
             one, quotient_anyfinds = anydivide(query,expr)
             if isinstance(one, Any_):
-                self._anyfind[one.anykey].append(Const(1))
+                self._anyfind[one.anykey].append(Rat(1))
                 join_dicts(self._anyfind, quotient_anyfinds)
                 return True
 

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -51,9 +51,7 @@ class Any_(Expr):
         return []
 
     def diff(self, var: "Symbol") -> "Expr":
-        raise NotImplementedError(
-            f"Cannot get the derivative of {self.__class__.__name__}"
-        )
+        raise NotImplementedError(f"Cannot get the derivative of {self.__class__.__name__}")
 
     def latex(self) -> str:
         raise NotImplementedError(f"Cannot convert {self.__class__.__name__} to latex")
@@ -145,10 +143,7 @@ def consolidate(query_anyfinds: _qanyfind, expr: Sum) -> EqResult:
     for query_term_repr, query_term_values in query_anyfinds.items():
         for expr_term_repr, matches in query_term_values.items():
             if all(
-                any(
-                    _anyfinds_eq(matches2, matches)
-                    for matches2 in query_term_values2.values()
-                )
+                any(_anyfinds_eq(matches2, matches) for matches2 in query_term_values2.values())
                 for query_term_values2 in query_anyfinds.values()
             ):
                 join_dicts(final, matches)
@@ -156,9 +151,7 @@ def consolidate(query_anyfinds: _qanyfind, expr: Sum) -> EqResult:
 
     assert all(all_same(v) for v in final.values())
     final = {k: v[0] for k, v in final.items()}
-    assert all(
-        any(_anyfinds_eq(x, final) for x in y.values()) for y in query_anyfinds.values()
-    )
+    assert all(any(_anyfinds_eq(x, final) for x in y.values()) for y in query_anyfinds.values())
 
     rest = Sum([t for t in expr.terms if repr(t) not in accounted_expr_terms])
     return {"anyfind": final, "rest": rest, "success": True}
@@ -220,10 +213,7 @@ class Eq:
                     for expr_term in expr.terms:
                         output = Eq(expr_term, query_term, decompose_singles=False)()
                         is_eq, anyfinds = output.get("success"), output.get("anyfind")
-                        if is_eq and all(
-                            any(_anyfinds_eq(x, anyfinds) for x in y)
-                            for y in query_anyfinds.values()
-                        ):
+                        if is_eq and all(any(_anyfinds_eq(x, anyfinds) for x in y) for y in query_anyfinds.values()):
                             query_anyfinds[repr(query_term)][repr(expr_term)] = anyfinds
 
                     if len(query_anyfinds[repr(query_term)]) == 0:
@@ -266,9 +256,7 @@ class Eq:
         if isinstance(expr, list):
             if not (isinstance(query, list) and len(expr) == len(query)):
                 return False
-            return len(expr) == len(query) and all(
-                [self._eq(e, q) for e, q in zip(expr, query)]
-            )
+            return len(expr) == len(query) and all([self._eq(e, q) for e, q in zip(expr, query)])
         if expr == query:
             return True
         if not isinstance(expr, Expr) or not isinstance(query, Expr):
@@ -304,12 +292,7 @@ class Eq:
 
         if not expr.__class__ == query.__class__:
             return False
-        return all(
-            [
-                self._eq(getattr(expr, field.name), getattr(query, field.name))
-                for field in fields(expr)
-            ]
-        )
+        return all([self._eq(getattr(expr, field.name), getattr(query, field.name)) for field in fields(expr)])
 
 
 def anydivide(num: Expr, denom: Expr) -> Tuple[Expr, AnyfindInProgress]:
@@ -400,9 +383,7 @@ def replace_factory(condition, perform) -> ExprFn:
     return replace_factory_list([condition], [perform])
 
 
-def replace_factory_list(
-    conditions: Iterable[Callable[[Expr], bool]], performs: Iterable[ExprFn]
-) -> ExprFn:
+def replace_factory_list(conditions: Iterable[Callable[[Expr], bool]], performs: Iterable[ExprFn]) -> ExprFn:
     """
     list of iterable conditions should be ... mutually exclusive or sth
 
@@ -433,9 +414,7 @@ def replace_factory_list(
         if len(expr.children()) == 0:  # Number, Symbol
             return expr
 
-        raise NotImplementedError(
-            f"replace not implemented for {expr.__class__.__name__}"
-        )
+        raise NotImplementedError(f"replace not implemented for {expr.__class__.__name__}")
 
     return _replace
 
@@ -444,9 +423,7 @@ def kinder_replace(expr: Expr, perform: OptionalExprFn, **kwargs) -> Expr:
     return kinder_replace_many(expr, [perform], **kwargs)
 
 
-def kinder_replace_many(
-    expr: Expr, performs: Iterable[OptionalExprFn], verbose=False, _d=False
-) -> Expr:
+def kinder_replace_many(expr: Expr, performs: Iterable[OptionalExprFn], verbose=False, _d=False) -> Expr:
     """
     kinder, bc some queries dont have a clean condition.
     ex: checking multiple any_ matches.
@@ -496,9 +473,7 @@ def replace(expr: Expr, old: Expr, new: Expr) -> Expr:
 
 
 # cls here has to be a subclass of singlefunc
-def replace_class(
-    expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callable[[Expr], Expr]]
-) -> Expr:
+def replace_class(expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callable[[Expr], Expr]]) -> Expr:
     # legacy // can be rewritten with replace_factory and put directly into transform RewriteTrig
     # bc it's not used anywhere else.
     # however it doesn't matter super much rn that everything is structured in :sparkles: prestine condition :sparkles:
@@ -527,6 +502,4 @@ def replace_class(
     if len(expr.children()) == 0:  # Number, Symbol
         return expr
 
-    raise NotImplementedError(
-        f"replace_class not implemented for {expr.__class__.__name__}"
-    )
+    raise NotImplementedError(f"replace_class not implemented for {expr.__class__.__name__}")

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -248,7 +248,7 @@ class Eq:
         if isinstance(expr, list):
             if not (isinstance(query, list) and len(expr) == len(query)):
                 return False
-            return len(expr) == len(query) and all([self._eq(e, q) for e, q in zip(expr, query)])
+            return len(expr) == len(query) and all(self._eq(e, q) for e, q in zip(expr, query))
         if expr == query:
             return True
         if not isinstance(expr, Expr) or not isinstance(query, Expr):
@@ -280,7 +280,7 @@ class Eq:
 
         if not expr.__class__ == query.__class__:
             return False
-        return all([self._eq(getattr(expr, field.name), getattr(query, field.name)) for field in fields(expr)])
+        return all(self._eq(getattr(expr, field.name), getattr(query, field.name)) for field in fields(expr))
 
 
 def divide_anys(num: Expr, denom: Expr) -> Tuple[Expr, MatchesInProgress]:
@@ -358,7 +358,7 @@ def contains_cls(expr: Expr, cls: Type[Expr]) -> bool:
     if isinstance(expr, cls):
         return True
 
-    return any([contains_cls(e, cls) for e in expr.children()])
+    return any(contains_cls(e, cls) for e in expr.children())
 
 
 def general_count(expr: Expr, condition: Callable[[Expr], bool]) -> int:

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -13,11 +13,14 @@ from .utils import ExprFn, OptionalExprFn, random_id
 
 
 class Any_(Expr):
+    _fields_already_casted = True
+
     def __init__(self, key=None, *, is_multiple_terms=False):
         if not key:
             key = random_id(10)
         self._key = key
         self._is_multiple_terms = is_multiple_terms
+        super().__post_init__()
 
     @property
     def key(self) -> str:

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -2,8 +2,6 @@
 
 This module is currently still developmental. It does the job often but is not promised to be robust
 outside of the cases it is currently used for. Use with caution.
-
-Still WIP. Ideally need to do stuff like "check if somefactor * cos(sth) + somefactor * sin(sth) exists."
 """
 
 from collections import defaultdict
@@ -84,32 +82,6 @@ def eq(expr: Expr, query: Expr, *, up_to_factor=False, up_to_sum=False) -> EqRes
             )
         expr, query = query, expr
     return Eq(expr, query, up_to_factor, up_to_sum=up_to_sum)()
-
-
-# @dataclass
-# class Inverse(Expr):
-#     inner: Expr # = 1
-
-#     def __eq__(self, other):
-#         return isinstance(other, Inverse) and other.inner == self.inner
-
-#     def __repr__(self) -> str:
-#         return f"Inverse({self.inner})"
-
-#     # implementing some Expr abstract methods
-#     def subs(self, subs: Dict[str, "Rat"]):
-#         raise NotImplementedError(f"Cannot evaluate {self}")
-
-#     def children(self) -> List["Expr"]:
-#         return self.inner
-
-#     def diff(self, var: "Symbol") -> "Expr":
-#         raise NotImplementedError(
-#             f"Cannot get the derivative of {self.__class__.__name__}"
-#         )
-
-#     def latex(self) -> str:
-#         raise NotImplementedError(f"Cannot convert {self.__class__.__name__} to latex")
 
 
 def get_anys(expr: Expr) -> List[Any_]:
@@ -302,10 +274,6 @@ class Eq:
                         join_dicts2(self._matches, quotient_matches)
                         self._matches[anys[0].key].append(anyvalue)
                         return True
-
-                # for a in anys:
-                #     self._anyfind[a.anykey].append(Inverse(one))
-                # return True
 
         if not expr.__class__ == query.__class__:
             return False

--- a/src/simpy/regex.py
+++ b/src/simpy/regex.py
@@ -1,7 +1,11 @@
 """Custom library for checking what shit exists. Replaces searching the repr with regex.
 
+This module is currently still developmental. It does the job often but is not promised to be robust
+outside of the cases it is currently used for. Use with caution.
+
 Still WIP. Ideally need to do stuff like "check if somefactor * cos(sth) + somefactor * sin(sth) exists."
 """
+
 from collections import defaultdict
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, Iterable, List, Literal, Tuple, Type
@@ -11,7 +15,7 @@ from .utils import ExprFn, OptionalExprFn, random_id
 
 
 class Any_(Expr):
-    def __init__(self, anykey = None, *, is_multiple_terms=False):
+    def __init__(self, anykey=None, *, is_multiple_terms=False):
         if not anykey:
             anykey = random_id(10)
         self._anykey = anykey
@@ -20,7 +24,7 @@ class Any_(Expr):
     @property
     def anykey(self) -> str:
         return self._anykey
-    
+
     @property
     def is_multiple_terms(self) -> bool:
         return self._is_multiple_terms
@@ -32,17 +36,17 @@ class Any_(Expr):
         #     return True
         # return NotImplemented
         return False
-    
+
     def __repr__(self) -> str:
         return "any_" + self.anykey
-    
+
     # implementing some Expr abstract methods
     def subs(self, subs: Dict[str, "Rat"]):
         raise NotImplementedError(f"Cannot evaluate {self}")
-    
+
     def _evalf(self, subs):
         raise NotImplementedError(f"Cannot evaluate {self}")
-    
+
     def children(self) -> List["Expr"]:
         return []
 
@@ -55,19 +59,20 @@ class Any_(Expr):
         raise NotImplementedError(f"Cannot convert {self.__class__.__name__} to latex")
 
 
-
 any_ = Any_()
 
 # smallTODO: make this a namedtuple
 EqResult = Dict[Literal["success", "factor", "rest", "anyfind"], Any]
 
+
 @cast
-def eq(expr: Expr, query: Expr, *, up_to_factor = False, up_to_sum=False) -> EqResult:
+def eq(expr: Expr, query: Expr, *, up_to_factor=False, up_to_sum=False) -> EqResult:
     if expr.has(Any_):
         if query.has(Any_):
             raise ValueError("Can't both arguments to eq have Any_")
         expr, query = query, expr
     return Eq(expr, query, up_to_factor, up_to_sum=up_to_sum)()
+
 
 # @dataclass
 # class Inverse(Expr):
@@ -75,14 +80,14 @@ def eq(expr: Expr, query: Expr, *, up_to_factor = False, up_to_sum=False) -> EqR
 
 #     def __eq__(self, other):
 #         return isinstance(other, Inverse) and other.inner == self.inner
-    
+
 #     def __repr__(self) -> str:
 #         return f"Inverse({self.inner})"
 
 #     # implementing some Expr abstract methods
 #     def subs(self, subs: Dict[str, "Rat"]):
 #         raise NotImplementedError(f"Cannot evaluate {self}")
-    
+
 #     def children(self) -> List["Expr"]:
 #         return self.inner
 
@@ -101,17 +106,18 @@ def get_anys(expr: Expr) -> List[Any_]:
 
     str_set = set([symbol.anykey for e in expr.children() for symbol in get_anys(e)])
     return [Any_(s) for s in str_set]
-            
 
-def all_same(list_: list):
+
+def all_same(list_: list) -> bool:
+    """returns whether all elements in the list are equal"""
     if len(list_) == 1:
         return True
-    for i in range(len(list_)-1):
-        if list_[i] != list_[i+1]:
+    for i in range(len(list_) - 1):
+        if list_[i] != list_[i + 1]:
             return False
-        
+
     return True
-    
+
 
 AnyfindInProgress = Dict[str, List[Expr]]
 Anyfind = Dict[str, Expr]
@@ -122,36 +128,54 @@ def _anyfinds_eq(x: Anyfind, y: Anyfind):
     for k in x:
         if k in y and not y[k] == x[k]:
             return False
-            
+
     for k in y:
         if k in x and not y[k] == x[k]:
             return False
-            
+
     return True
 
+
 _qanyfind = Dict[str, Dict[str, Anyfind]]
+
+
 def consolidate(query_anyfinds: _qanyfind, expr: Sum) -> EqResult:
     final = defaultdict(list)
     accounted_expr_terms = []
     for query_term_repr, query_term_values in query_anyfinds.items():
         for expr_term_repr, matches in query_term_values.items():
-            if all(any(_anyfinds_eq(matches2, matches) for matches2 in query_term_values2.values()) for query_term_values2 in query_anyfinds.values()):
+            if all(
+                any(
+                    _anyfinds_eq(matches2, matches)
+                    for matches2 in query_term_values2.values()
+                )
+                for query_term_values2 in query_anyfinds.values()
+            ):
                 join_dicts(final, matches)
                 accounted_expr_terms.append(expr_term_repr)
 
-
     assert all(all_same(v) for v in final.values())
     final = {k: v[0] for k, v in final.items()}
-    assert all(any(_anyfinds_eq(x, final) for x in y) for y in query_anyfinds.values())
-    
+    assert all(
+        any(_anyfinds_eq(x, final) for x in y.values()) for y in query_anyfinds.values()
+    )
+
     rest = Sum([t for t in expr.terms if repr(t) not in accounted_expr_terms])
     return {"anyfind": final, "rest": rest, "success": True}
 
 
 class Eq:
-    """Create a new instance every time you run an Eq comparison.
-    """
-    def __init__(self, expr: Expr, query: Expr, up_to_factor: bool = False, decompose_singles=True, up_to_sum=False, _is_divide=False):
+    """Create a new instance every time you run an Eq comparison."""
+
+    def __init__(
+        self,
+        expr: Expr,
+        query: Expr,
+        up_to_factor: bool = False,
+        decompose_singles=True,
+        up_to_sum=False,
+        _is_divide=False,
+    ):
         if expr.has(Any_):
             raise ValueError("Only query can contain 'any' objects.")
 
@@ -172,8 +196,7 @@ class Eq:
             self._query = new_query.expand() if new_query.expandable() else new_query
 
     def __call__(self) -> EqResult:
-        """Returns (is_equal, factor, anyfinds) if up_to_factor=True and (is_equal, anyfinds) otherwise.
-        """
+        """Returns (is_equal, factor, anyfinds) if up_to_factor=True and (is_equal, anyfinds) otherwise."""
         falsereturn = {"success": False}
         if self._up_to_sum:
             # Usually, this means that self._expr is a sum and self._query is also a sum.
@@ -182,12 +205,12 @@ class Eq:
                 raise NotImplementedError
             if not len(self._query.terms) <= len(self._expr.terms):
                 return falsereturn
-            
+
             # i want to prioritize most exact returns first.
             # actually i want to have most exact return only fuck shit lmao
 
             # xx = [[self._eq(expr_term, term) for expr_term in self._expr.terms] for term in self._query.terms]
-            
+
             # return the anyfind of each one
             # if there is like sth in each query terms where the anyfind is the same...
 
@@ -197,14 +220,17 @@ class Eq:
                     for expr_term in expr.terms:
                         output = Eq(expr_term, query_term, decompose_singles=False)()
                         is_eq, anyfinds = output.get("success"), output.get("anyfind")
-                        if is_eq and all(any(_anyfinds_eq(x, anyfinds) for x in y) for y in query_anyfinds.values()):
+                        if is_eq and all(
+                            any(_anyfinds_eq(x, anyfinds) for x in y)
+                            for y in query_anyfinds.values()
+                        ):
                             query_anyfinds[repr(query_term)][repr(expr_term)] = anyfinds
 
-                    if query_anyfinds[repr(query_term)] == []:
+                    if len(query_anyfinds[repr(query_term)]) == 0:
                         return {"success": False}
-                
+
                 return consolidate(query_anyfinds, expr)
-            
+
             result = _is_sum_eq(self._expr, self._query)
             if result["success"] is False:
                 return falsereturn
@@ -240,7 +266,9 @@ class Eq:
         if isinstance(expr, list):
             if not (isinstance(query, list) and len(expr) == len(query)):
                 return False
-            return all([self._eq(e, q) for e, q in zip(expr, query)])
+            return len(expr) == len(query) and all(
+                [self._eq(e, q) for e, q in zip(expr, query)]
+            )
         if expr == query:
             return True
         if not isinstance(expr, Expr) or not isinstance(query, Expr):
@@ -250,10 +278,10 @@ class Eq:
             return True
         if not query.has(Any_):
             return False
-        
+
         if not self._is_divide:
             # You don't get to divide if we already is --- prevents inf recursion.
-            one, quotient_matches = anydivide(query,expr)
+            one, quotient_matches = anydivide(query, expr)
             if isinstance(one, Any_):
                 self._anyfind[one.anykey].append(Rat(1))
                 join_dicts2(self._anyfind, quotient_matches)
@@ -273,15 +301,20 @@ class Eq:
                 # for a in anys:
                 #     self._anyfind[a.anykey].append(Inverse(one))
                 # return True
-        
+
         if not expr.__class__ == query.__class__:
             return False
-        return all([self._eq(getattr(expr, field.name), getattr(query, field.name)) for field in fields(expr)])
+        return all(
+            [
+                self._eq(getattr(expr, field.name), getattr(query, field.name))
+                for field in fields(expr)
+            ]
+        )
 
 
 def anydivide(num: Expr, denom: Expr) -> Tuple[Expr, AnyfindInProgress]:
-    """Returns: (quotient, anyfinds)
-    """
+    """Returns: (quotient, anyfinds)"""
+
     def _make_factors_list(expr: Expr) -> List[Expr]:
         if not isinstance(expr, Prod):
             return [expr]
@@ -323,10 +356,12 @@ def anydivide(num: Expr, denom: Expr) -> Tuple[Expr, AnyfindInProgress]:
     new_nf = [nf for nf in numfactors if nf is not None]
     return Prod(new_nf) / Prod(new_df), anyfinds
 
+
 def join_dicts(d1: AnyfindInProgress, d2: Anyfind) -> None:
     """Mutates d1 to add the stuff in d2"""
     for k in d2.keys():
         d1[k].append(d2[k])
+
 
 def join_dicts2(d1: AnyfindInProgress, d2: AnyfindInProgress) -> None:
     """Mutates d1 to add the stuff in d2"""
@@ -336,10 +371,10 @@ def join_dicts2(d1: AnyfindInProgress, d2: AnyfindInProgress) -> None:
         else:
             d1[k] = d2[k]
 
+
 @cast
 def count(expr: Expr, query: Expr) -> int:
-    """Counts how many times `query` appears in `expr`. Exact matches only.
-    """
+    """Counts how many times `query` appears in `expr`. Exact matches only."""
     if isinstance(expr, query.__class__) and expr == query:
         return 1
     return sum(count(e, query) for e in expr.children())
@@ -353,7 +388,7 @@ def contains_cls(expr: Expr, cls: Type[Expr]) -> bool:
 
 
 def general_count(expr: Expr, condition: Callable[[Expr], bool]) -> int:
-    """the `count` function above, except you can specify a condition rather than 
+    """the `count` function above, except you can specify a condition rather than
     only allowing exact matches.
     """
     if condition(expr):
@@ -365,13 +400,16 @@ def replace_factory(condition, perform) -> ExprFn:
     return replace_factory_list([condition], [perform])
 
 
-def replace_factory_list(conditions: Iterable[Callable[[Expr], bool]], performs: Iterable[ExprFn]) -> ExprFn:
+def replace_factory_list(
+    conditions: Iterable[Callable[[Expr], bool]], performs: Iterable[ExprFn]
+) -> ExprFn:
     """
     list of iterable conditions should be ... mutually exclusive or sth
 
     every time the condition returns True, you replace that expr with the output of `perform`
     hard to explain in English. read the code.
     """
+
     # Ok honestly the factory might not be the best structure, might be better to have a single unested function that returns the replaced expr directly
     # or make a class bc they're cleaner than factories. haven't given this a ton of thought but we don't need the most perfect choice <3
     def _replace(expr: Expr) -> Expr:
@@ -391,18 +429,24 @@ def replace_factory_list(conditions: Iterable[Callable[[Expr], bool]], performs:
         # i love recursion
         if isinstance(expr, SingleFunc):
             return expr.__class__(_replace(expr.inner))
-        
-        if len(expr.children()) == 0: # Number, Symbol
+
+        if len(expr.children()) == 0:  # Number, Symbol
             return expr
-        
-        raise NotImplementedError(f"replace not implemented for {expr.__class__.__name__}")
+
+        raise NotImplementedError(
+            f"replace not implemented for {expr.__class__.__name__}"
+        )
 
     return _replace
+
 
 def kinder_replace(expr: Expr, perform: OptionalExprFn, **kwargs) -> Expr:
     return kinder_replace_many(expr, [perform], **kwargs)
 
-def kinder_replace_many(expr: Expr, performs: Iterable[OptionalExprFn], verbose=False, _d=False) -> Expr:
+
+def kinder_replace_many(
+    expr: Expr, performs: Iterable[OptionalExprFn], verbose=False, _d=False
+) -> Expr:
     """
     kinder, bc some queries dont have a clean condition.
     ex: checking multiple any_ matches.
@@ -433,20 +477,18 @@ def kinder_replace_many(expr: Expr, performs: Iterable[OptionalExprFn], verbose=
         # i love recursion
         if isinstance(e, SingleFunc):
             return e.__class__(_replace(e.inner))
-        
-        if len(e.children()) == 0: # Number, Symbol
+
+        if len(e.children()) == 0:  # Number, Symbol
             return e
-        
+
         raise NotImplementedError(f"replace not implemented for {e.__class__.__name__}")
 
     ans = _replace(expr)
     return (ans, is_hit["hi"]) if verbose else ans
 
 
-
 def replace(expr: Expr, old: Expr, new: Expr) -> Expr:
-    """replaces every instance of `old` (that appears in `expr`) with `new`. 
-    """
+    """replaces every instance of `old` (that appears in `expr`) with `new`."""
     # Special case of the general replace_factory that gets used often.
     condition = lambda e: isinstance(e, old.__class__) and e == old
     perform = lambda e: new
@@ -454,7 +496,9 @@ def replace(expr: Expr, old: Expr, new: Expr) -> Expr:
 
 
 # cls here has to be a subclass of singlefunc
-def replace_class(expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callable[[Expr], Expr]]) -> Expr:
+def replace_class(
+    expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callable[[Expr], Expr]]
+) -> Expr:
     # legacy // can be rewritten with replace_factory and put directly into transform RewriteTrig
     # bc it's not used anywhere else.
     # however it doesn't matter super much rn that everything is structured in :sparkles: prestine condition :sparkles:
@@ -471,7 +515,7 @@ def replace_class(expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callabl
     if isinstance(expr, log):
         return log(
             inner=replace_class(expr.inner, cls, newfunc),
-            base=replace_class(expr.base, cls, newfunc)
+            base=replace_class(expr.base, cls, newfunc),
         )
     if isinstance(expr, SingleFunc):
         new_inner = replace_class(expr.inner, cls, newfunc)
@@ -480,7 +524,7 @@ def replace_class(expr: Expr, cls: List[Type[SingleFunc]], newfunc: List[Callabl
                 return newfunc[i](new_inner)
         return expr.__class__(new_inner)
 
-    if len(expr.children()) == 0: # Number, Symbol
+    if len(expr.children()) == 0:  # Number, Symbol
         return expr
 
     raise NotImplementedError(

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -1,7 +1,7 @@
 from typing import Iterable, List, Optional, Tuple, Type, Union
 
-from .expr import (Abs, Const, Expr, Power, Prod, Sum, Symbol, TrigFunction,
-                   cos, cot, csc, log, nesting, sec, sin, tan)
+from .expr import (Abs, Expr, Power, Prod, Rat, Sum, Symbol, TrigFunction, cos,
+                   cot, csc, log, nesting, sec, sin, tan)
 from .regex import (any_, eq, general_count, kinder_replace,
                     kinder_replace_many, replace_class, replace_factory)
 from .utils import ExprFn
@@ -71,7 +71,7 @@ def _pythagorean_perform(sum: Expr) -> Optional[Expr]:
         def is_(f):
             return isinstance(f, Power) and f.exponent == 2 and isinstance(f.base, cls)
         if is_(term):
-            return term.base.inner, Const(1)  
+            return term.base.inner, Rat(1)  
 
         if not isinstance(term, Prod):
             return None
@@ -129,13 +129,13 @@ def rewrite_as_one_fraction(sum: Expr) -> Expr:
     for term in sum.terms:
         if isinstance(term, Prod):
             num, den = term.numerator_denominator
-        elif isinstance(term, Power) and isinstance(term.exponent, Const) and term.exponent.value < 0:
-            num, den = Const(1), Power(term.base, -term.exponent)
+        elif isinstance(term, Power) and isinstance(term.exponent, Rat) and term.exponent.value < 0:
+            num, den = Rat(1), Power(term.base, -term.exponent)
         else:
-            num, den = term, Const(1)
+            num, den = term, Rat(1)
         list_of_terms.append((num, den))
 
-    common_den = Const(1)
+    common_den = Rat(1)
     for _, den in list_of_terms:
         ratio = den / common_den
         common_den *= ratio
@@ -159,7 +159,7 @@ def _reciprocate_trigs(expr: Expr) -> Optional[Expr]:
     # just having this run in the integration simplify transform makes tests .5s slower (4.5 -> 5)
     b = expr.base
     x = expr.exponent
-    if isinstance(x, Const) and x < 0 and isinstance(b, TrigFunction) and not b.is_inverse:
+    if isinstance(x, Rat) and x < 0 and isinstance(b, TrigFunction) and not b.is_inverse:
         new_b = b.reciprocal_class(b.inner)
         return Power(new_b, -x)
 

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -60,11 +60,12 @@ def _pythagorean_perform(sum: Expr) -> Optional[Expr]:
         (1 - cos(any_) ** 2, lambda x: sin(x) ** 2),
     ]
     for cond, perform in identities:
-        is_eq, factor, inner = eq(sum, cond, up_to_factor=True, up_to_sum=True)
-        breakpoint()
-        if is_eq:
-            new_sum = factor * perform(inner)
-            return new_sum
+        result = eq(sum, cond, up_to_factor=True, up_to_sum=True)
+        if result["success"]:
+            factor = result["factor"]
+            inner = result["anyfind"]
+            rest = result["rest"]
+            return factor * perform(inner) + rest
 
     ##------------ Simplify sin^2(...) + cos^2(...) ------------##
     def is_thing_squared(term: Expr, cls: Union[Type[TrigFunction], Iterable[Type[TrigFunction]]]) -> Optional[Tuple[Expr, Expr]]: # returns inner, factor
@@ -175,8 +176,10 @@ def _combine_trigs(expr: Expr) -> Optional[Expr]:
         (cos(any_) * csc(any_), lambda x: cot(x)),
     ]
     for cond, perform in identities:
-        is_eq, factor, inner = eq(expr, cond, up_to_factor=True)
-        if is_eq:
+        result = eq(expr, cond, up_to_factor=True)
+        if result["success"]:
+            factor = result["factor"]
+            inner = result["anyfind"]
             new = factor * perform(inner)
             return new
 

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -1,59 +1,211 @@
 from typing import Iterable, List, Optional, Tuple, Type, Union
 
-from .expr import (Const, Expr, Power, Prod, Sum, TrigFunction, cos, cot, csc,
-                   sec, sin, tan)
-from .regex import any_, eq
+from .expr import (Abs, Const, Expr, Power, Prod, Sum, Symbol, TrigFunction,
+                   cos, cot, csc, log, nesting, sec, sin, tan)
+from .regex import (any_, eq, general_count, kinder_replace,
+                    kinder_replace_many, replace_class, replace_factory)
 from .utils import ExprFn
 
 
-def trig_simplification(sum: Sum) -> Expr:
-    if sum.has(TrigFunction):
-        ##------------ Simplify 1 +/- cls(...)^2 ------------##
-        # - for this case: what if there is a constant (or variable) common factor?
-        identities: List[Tuple[Expr, ExprFn]] = [
-            (1 + tan(any_) ** 2, lambda x: sec(x) ** 2),
-            (1 + cot(any_) ** 2, lambda x: csc(x) ** 2),
-            (1 - sin(any_) ** 2, lambda x: cos(x) ** 2),
-            (1 - cos(any_) ** 2, lambda x: sin(x) ** 2),
-            (1 - tan(any_) ** 2, lambda x: 1 / tan(x) ** 2), # unclear if this is even simpler...
-            (1 - cot(any_) ** 2, lambda x: 1 / cot(x) ** 2)
-        ]
-        for condition, perform in identities:
-            is_eq, factor, inner = eq(sum, condition, up_to_factor=True)
-            if is_eq:
-                new_sum = factor * perform(inner)
-                return new_sum.simplify()
+def expand_logs(expr: Expr, **kwargs) -> Expr:
+    return kinder_replace(expr, _log_perform, **kwargs)
 
-        ##------------ Simplify sin^2(...) + cos^2(...) ------------##
-        def is_thing_squared(term: Expr, cls: Union[Type[TrigFunction], Iterable[Type[TrigFunction]]]) -> Optional[Tuple[Expr, Expr]]: # returns inner, factor
-            def is_(f):
-                return isinstance(f, Power) and f.exponent == 2 and isinstance(f.base, cls)
-            if is_(term):
-                return term.base.inner, Const(1)  
-
-            if not isinstance(term, Prod):
-                return None
-            for f in term.terms:
-                if is_(f):
-                    return f.base.inner, term/f
-            return None
-
-        def sin_cos_condition(expr: Sum):
-            # make sure that a*cos^2(...) and a*sin^2(...) are both terms of this sum
-            # with an optional factor that may or may not be there of a
-            s = [is_thing_squared(term, sin) for term in expr.terms]
-            c = [is_thing_squared(term, cos) for term in expr.terms]
-            return [el for el in s if el is not None and el in c] 
-        
-        both_inners = sin_cos_condition(sum)
-        if len(both_inners) > 0:
-            new_terms = [t for t in sum.terms if not is_thing_squared(t, (sin, cos)) in both_inners]
-            new_terms += [el[1] for el in both_inners]
-            return Sum(new_terms).simplify()
-
-        # other_table = [
-        #     (r"^sec\((.+)\)\^2$", r"^-tan\((.+)\)\^2$", Const(1)),
-        # ]
-                        
-    return sum
+def _log_perform(expr: Expr) -> Optional[Expr]:
+    if not isinstance(expr, log):
+        return
+    inner = expr.inner
+    # IDK if this should be in simplify or if it should be like expand, in a diff function
+    # like you can move stuff together or move stuff apart
+    if isinstance(inner, Power):
+        return (log(inner.base) * inner.exponent)
+    if isinstance(inner, Prod):
+        return Sum([log(t) for t in inner.terms])
+    if isinstance(inner, Sum) and isinstance(inner.factor(), Prod):
+        return Sum([log(t) for t in inner.factor().terms])
     
+    # let's agree on some standards
+    # i dont love this, can change
+    if isinstance(inner, (sec, csc, cot)):
+        return -1 * log(inner.reciprocal_class(inner.inner))
+    
+    # ugly patch lmfao. need better overall philosophy for this stuff.
+    if isinstance(inner, Abs) and isinstance(inner.inner, Power):
+        return (log(abs(inner.inner.base)) * inner.inner.exponent)
+    if isinstance(inner, Abs) and isinstance(inner.inner, Prod):
+        return Sum([log(abs(term)) for term in inner.inner.terms])
+    if isinstance(inner, Abs) and isinstance(inner.inner, Sum) and isinstance(inner.inner.factor(), Prod):
+        return Sum([log(abs(term)) for term in inner.inner.factor().terms])
+    
+    return log(inner)
+
+
+def pythagorean_simplification(expr: Expr, **kwargs) -> Expr:
+    verbose = kwargs.get("verbose", False)
+    if not expr.has(TrigFunction):
+        return expr if not verbose else expr, False
+    return kinder_replace(expr, _pythagorean_perform, **kwargs)
+
+def _pythagorean_perform(sum: Expr) -> Optional[Expr]:
+    if not isinstance(sum, Sum):
+        return
+
+    ##------------ Simplify 1 +/- cls(...)^2 ------------##
+    # - for this case: what if there is a constant (or variable) common factor?
+    identities: List[Tuple[Expr, ExprFn]] = [
+        (1 + tan(any_) ** 2, lambda x: sec(x) ** 2),
+        (-1 + sec(any_) ** 2, lambda x: tan(x) ** 2),
+        (1 + cot(any_) ** 2, lambda x: csc(x) ** 2),
+        (-1 + csc(any_) ** 2, lambda x: cot(x) ** 2),
+        (1 - sin(any_) ** 2, lambda x: cos(x) ** 2),
+        (1 - cos(any_) ** 2, lambda x: sin(x) ** 2),
+    ]
+    for condition, perform in identities:
+        is_eq, factor, inner = eq(sum, condition, up_to_factor=True)
+        if is_eq:
+            new_sum = factor * perform(inner)
+            return new_sum
+
+    ##------------ Simplify sin^2(...) + cos^2(...) ------------##
+    def is_thing_squared(term: Expr, cls: Union[Type[TrigFunction], Iterable[Type[TrigFunction]]]) -> Optional[Tuple[Expr, Expr]]: # returns inner, factor
+        def is_(f):
+            return isinstance(f, Power) and f.exponent == 2 and isinstance(f.base, cls)
+        if is_(term):
+            return term.base.inner, Const(1)  
+
+        if not isinstance(term, Prod):
+            return None
+        for f in term.terms:
+            if is_(f):
+                return f.base.inner, term/f
+        return None
+
+    def sin_cos_condition(expr: Sum):
+        # make sure that a*cos^2(...) and a*sin^2(...) are both terms of this sum
+        # with an optional factor that may or may not be there of a
+        s = [is_thing_squared(term, sin) for term in expr.terms]
+        c = [is_thing_squared(term, cos) for term in expr.terms]
+        return [el for el in s if el is not None and el in c] 
+    
+    both_inners = sin_cos_condition(sum)
+    if len(both_inners) > 0:
+        new_terms = [t for t in sum.terms if not is_thing_squared(t, (sin, cos)) in both_inners]
+        new_terms += [el[1] for el in both_inners]
+        return Sum(new_terms)
+
+    # other_table = [
+    #     (r"^sec\((.+)\)\^2$", r"^-tan\((.+)\)\^2$", Const(1)),
+    # ]
+                        
+
+def _pythagorean_complex_perform(sum: Expr) -> Optional[Expr]:
+    if not isinstance(sum, Sum):
+        return
+    ##------------ More complex pythagorean simplification across terms ------------##
+    new_sum = replace_class(
+        sum,
+        [tan, csc, cot, sec],
+        [
+            lambda x: sin(x) / cos(x),
+            lambda x: 1 / sin(x),
+            lambda x: cos(x) / sin(x),
+            lambda x: 1 / cos(x),
+        ],
+    )
+    new_sum = rewrite_as_one_fraction(new_sum)
+    if sum == new_sum:
+        return
+    new_sum = pythagorean_simplification(new_sum)
+    if is_simpler(new_sum, sum):
+        # assume we're doing this in the ctx of the larger simplification
+        return reciprocate_trigs(new_sum)
+
+    
+def rewrite_as_one_fraction(sum: Expr) -> Expr:
+    """Rewrites with common denominator"""
+    if not isinstance(sum, Sum):
+        return sum
+    list_of_terms: List[Tuple[Expr, Expr]] = []
+    for term in sum.terms:
+        if isinstance(term, Prod):
+            num, den = term.numerator_denominator
+        elif isinstance(term, Power) and isinstance(term.exponent, Const) and term.exponent.value < 0:
+            num, den = Const(1), Power(term.base, -term.exponent)
+        else:
+            num, den = term, Const(1)
+        list_of_terms.append((num, den))
+
+    common_den = Const(1)
+    for _, den in list_of_terms:
+        ratio = den / common_den
+        common_den *= ratio
+    
+    new_nums = [num * common_den / den for num, den in list_of_terms]
+    return Sum(new_nums) / common_den
+
+def is_simpler(a, b):
+    """return if a is simpler than b"""
+    def count(e):
+        # counts the number of symbols
+        return general_count(e, lambda x: isinstance(x, Symbol))
+    return count(a) < count(b)
+
+
+def _reciprocate_trigs(expr: Expr) -> Optional[Expr]:
+    if not isinstance(expr, Power):
+        return
+    # in general during integration it's not useful to apply this simplify; it's only
+    # useful for simplifying the expression for the user to see & for subtractions.
+    # just having this run in the integration simplify transform makes tests .5s slower (4.5 -> 5)
+    b = expr.base
+    x = expr.exponent
+    if isinstance(x, Const) and x < 0 and isinstance(b, TrigFunction) and not b.is_inverse:
+        new_b = b.reciprocal_class(b.inner)
+        return Power(new_b, -x)
+
+
+def _combine_trigs(expr: Expr) -> Optional[Expr]:
+    if not isinstance(expr, Prod):
+        return
+    # if sin(x)/cos(x) is in the product, combine it to tan(x)
+    identities: List[Tuple[Expr, ExprFn]] = [
+        # (sin(any_) / cos(any_), lambda x: tan(x)), # if we put this after reciprocate trigs, these won't exist.
+        (sin(any_) * sec(any_), lambda x: tan(x)),
+        # (cos(any_) / sin(any_), lambda x: cot(x)),
+        (cos(any_) * csc(any_), lambda x: cot(x)),
+    ]
+    for cond, perform in identities:
+        is_eq, factor, inner = eq(expr, cond, up_to_factor=True)
+        if is_eq:
+            new = factor * perform(inner)
+            return new
+
+
+def reciprocate_trigs(expr: Expr, **kwargs) -> Expr:
+    return kinder_replace_many(
+        expr,
+        [
+            _reciprocate_trigs,
+        ],
+        **kwargs
+    )
+
+
+def simplify(expr: Expr) -> Expr:
+    """Simplifies an expression.
+    
+    This is the general one that does all heuristics & is for aesthetics (& comparisons).
+    Use more specific simplification functions in integration please.
+    """
+    if expr.has(TrigFunction):
+        expr = trig_simplify(expr)
+    if expr.has(log):
+        expr = expand_logs(expr)
+    return expr
+
+
+def trig_simplify(expr):
+    # reciprocate and combine trigs is last because sometimes the pythag complex simplification will
+    # generate new trigs in the num/denom that can be simplified down.
+    expr = kinder_replace_many(expr, [_pythagorean_perform, _pythagorean_complex_perform, _reciprocate_trigs])
+    expr = kinder_replace_many(expr, [_combine_trigs])
+    return expr

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -1,32 +1,7 @@
 from typing import Iterable, List, Optional, Tuple, Type, Union
 
-from .expr import (
-    Abs,
-    Expr,
-    Power,
-    Prod,
-    Rat,
-    Sum,
-    Symbol,
-    TrigFunction,
-    cos,
-    cot,
-    csc,
-    log,
-    nesting,
-    sec,
-    sin,
-    tan,
-)
-from .regex import (
-    any_,
-    eq,
-    general_count,
-    kinder_replace,
-    kinder_replace_many,
-    replace_class,
-    replace_factory,
-)
+from .expr import Abs, Expr, Power, Prod, Rat, Sum, Symbol, TrigFunction, cos, cot, csc, log, nesting, sec, sin, tan
+from .regex import any_, eq, general_count, kinder_replace, kinder_replace_many, replace_class, replace_factory
 from .utils import ExprFn
 
 

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -63,7 +63,7 @@ def _pythagorean_perform(sum: Expr) -> Optional[Expr]:
         result = eq(sum, cond, up_to_factor=True, up_to_sum=True)
         if result["success"]:
             factor = result["factor"]
-            inner = result["anyfind"]
+            inner = result["matches"]
             rest = result["rest"]
             return factor * perform(inner) + rest
 
@@ -185,7 +185,7 @@ def _combine_trigs(expr: Expr) -> Optional[Expr]:
         result = eq(expr, cond, up_to_factor=True)
         if result["success"]:
             factor = result["factor"]
-            inner = result["anyfind"]
+            inner = result["matches"]
             new = factor * perform(inner)
             return new
 

--- a/src/simpy/simplify.py
+++ b/src/simpy/simplify.py
@@ -59,8 +59,9 @@ def _pythagorean_perform(sum: Expr) -> Optional[Expr]:
         (1 - sin(any_) ** 2, lambda x: cos(x) ** 2),
         (1 - cos(any_) ** 2, lambda x: sin(x) ** 2),
     ]
-    for condition, perform in identities:
-        is_eq, factor, inner = eq(sum, condition, up_to_factor=True)
+    for cond, perform in identities:
+        is_eq, factor, inner = eq(sum, cond, up_to_factor=True, up_to_sum=True)
+        breakpoint()
         if is_eq:
             new_sum = factor * perform(inner)
             return new_sum

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -70,11 +70,31 @@ class Node:
         return self._children
 
     def add_child(self, child: "Node") -> None:
+
+        def eq_with_var(a, b) -> bool:
+            a_expr, a_var = a
+            b_expr, b_var = b
+
+            def _recursive_call(e1: Expr, e2: Expr) -> bool:
+                if type(e1) != type(e2):
+                    return False
+                if isinstance(e1, Symbol):
+                    if e1 == a_var:
+                        return e2 == b_var
+                    return e1 == e2
+                c1 = e1.children()
+                c2 = e2.children()
+                if c1 == [] or c2 == []:
+                    return e1 == e2
+                if len(c1) != len(c2):
+                    return False
+                return all(_recursive_call(x, y) for x, y in zip(c1, c2))
+            
+            return _recursive_call(a_expr, b_expr)
+
         if not child.is_filler:
             parents = _parents(self)
-            info = lambda p: repr(replace(p.expr, p.var, self.var))
-            parents_info = [info(p) for p in parents if not p.is_filler]
-            if info(child) in parents_info:
+            if any(eq_with_var((p.expr, p.var), (child.expr, child.var)) for p in parents):
                 return
         self.children.append(child)
 

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -1153,7 +1153,8 @@ class CompleteTheSquare(Transform):
 
 class RewritePythagorean(Transform):
     """
-
+    sin(x)^(2n+1) -> sin(x) (1-cos^2(x))^n
+    
     ykw idk if this transform has ever helped anyone when it's not performed at the outer level of nesting.
     """
     @staticmethod

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -31,7 +31,7 @@ from .expr import (
 )
 from .linalg import invert
 from .polynomial import Polynomial, is_polynomial, polynomial_to_expr, rid_ending_zeros, to_const_polynomial
-from .regex import count, general_count, kinder_replace, replace, replace_class, replace_factory
+from .regex import count, general_contains, kinder_replace, replace, replace_class, replace_factory
 from .simplify import pythagorean_simplification
 from .utils import ExprFn, random_id
 
@@ -853,7 +853,7 @@ class ProductToSum(Transform):
         if super().check(node) is False:
             return False
 
-        return general_count(node.expr, self.condition) > 0
+        return general_contains(node.expr, self.condition)
 
     def forward(self, node: Node) -> None:
         new_integrand = kinder_replace(node.expr, self.perform_opt)
@@ -1167,7 +1167,7 @@ class CompleteTheSquare(Transform):
             # which means that there's no square to complete.
             # the result will just be the same as the original.
 
-        return general_count(node.expr, condition) > 0
+        return general_contains(node.expr, condition)
 
     def forward(self, node: Node) -> None:
         # replace all quadratics with their completed-the-square form
@@ -1227,7 +1227,7 @@ class RewritePythagorean(Transform):
             return False
 
         # this is a complete waste of resources.
-        return general_count(node.expr, self.condition) > 0
+        return general_contains(node.expr, self.condition)
 
     def forward(self, node: Node) -> bool:
         def _replace_factory(c, p, e):

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -7,8 +7,8 @@ from typing import Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
 
-from .expr import (Expr, Power, Prod, Rat, Sum, Symbol, TrigFunction, asin,
-                   atan, cos, cot, csc, log, nesting, remove_const_factor, sec,
+from .expr import (Expr, Num, Power, Prod, Rat, Sum, Symbol, TrigFunction,
+                   asin, atan, cos, cot, csc, log, remove_const_factor, sec,
                    sin, sqrt, symbols, tan)
 from .linalg import invert
 from .polynomial import (Polynomial, is_polynomial, polynomial_to_expr,
@@ -608,7 +608,7 @@ class LinearUSub(Transform):
                 coeff = (expr / xyz)
                 if coeff == Rat(1):
                     return None
-                coeff_abs = coeff.abs() if isinstance(coeff, Rat) else coeff
+                coeff_abs = abs(coeff) if isinstance(coeff, Num) else coeff
                 inner_coeff = Power(coeff_abs, 1 / xyz.exponent)
                 return inner_coeff * node.var, lambda u: u / inner_coeff
             return None

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -89,7 +89,7 @@ class Node:
                 if len(c1) != len(c2):
                     return False
                 return all(_recursive_call(x, y) for x, y in zip(c1, c2))
-            
+
             return _recursive_call(a_expr, b_expr)
 
         if not child.is_filler:
@@ -148,10 +148,10 @@ class Node:
 
         if self.type == "AND" or self.type == "UNSET":
             # UNSET should only have one child.
-            return all([child.is_solved for child in self.children])
+            return all(child.is_solved for child in self.children)
 
         if self.type == "OR":
-            return any([child.is_solved for child in self.children])
+            return any(child.is_solved for child in self.children)
 
     @property
     def is_failed(self) -> bool:
@@ -165,9 +165,9 @@ class Node:
             return False
 
         if self.type == "OR":
-            return all([child.is_failed for child in self.children])
+            return all(child.is_failed for child in self.children)
 
-        return any([child.is_failed for child in self.children])
+        return any(child.is_failed for child in self.children)
 
     @property
     def is_finished(self) -> bool:
@@ -345,7 +345,7 @@ class Additivity(SafeTransform):
         super().backward(node)
 
         # For this to work, we must have a solution for each sibling.
-        if not all([child.solution for child in node.parent.children]):
+        if not all(child.solution for child in node.parent.children):
             raise ValueError(f"Additivity backward for {node} failed")
 
         node.parent.solution = Sum([child.solution for child in node.parent.children])
@@ -602,7 +602,7 @@ class LinearUSub(Transform):
         ) -> Optional[Tuple[Expr, Optional[ExprFn]]]:
             """Returns what u should be in terms of x. & None if it's not."""
             if isinstance(expr, Sum):
-                if all([not c.contains(node.var) or not (c / node.var).contains(node.var) for c in expr.terms]):
+                if all(not c.contains(node.var) or not (c / node.var).contains(node.var) for c in expr.terms):
                     return expr, None
             if isinstance(expr, Prod):
                 # Is a constant multiple of var
@@ -648,7 +648,7 @@ class LinearUSub(Transform):
                 # have to do this because all([]) = True. Covering my bases.
                 return False
             else:
-                return all([_check(child) for child in e.children()])
+                return all(_check(child) for child in e.children())
 
         return _check(node.expr)
 
@@ -687,7 +687,7 @@ class CompoundAngle(Transform):
             ):
                 return True
             else:
-                return any([_check(child) for child in e.children()])
+                return any(_check(child) for child in e.children())
 
         return _check(node.expr)
 

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -53,11 +53,12 @@ class Node:
         return self._children
     
     def add_child(self, child: "Node") -> None:
-        parents = _parents(self)
-        info = lambda p: repr(replace(p.expr, p.var, self.var))
-        parents_info = [info(p) for p in parents if not p.is_filler]
-        if info(child) in parents_info:
-            return
+        if not child.is_filler:
+            parents = _parents(self)
+            info = lambda p: repr(replace(p.expr, p.var, self.var))
+            parents_info = [info(p) for p in parents if not p.is_filler]
+            if info(child) in parents_info:
+                return
         self.children.append(child)
 
     def add_children(self, children: List["Node"]) -> None:
@@ -965,7 +966,7 @@ class ByParts(Transform):
                     assert parent_byparts.is_solved
                     return
             ###
-            
+
             funky_node = Node(node.expr, node.var, tr, node, type="AND", is_filler=True)
             funky_node.add_children([
                 Node(

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -1198,8 +1198,10 @@ class Simplify(Transform):
     def check(self, node: Node) -> bool:
         if super().check(node) is False:
             return False
-
-        if isinstance(_get_last_heuristic_transform(node), RewritePythagorean):
+        
+        t = _get_last_heuristic_transform(node)
+        # The point of these 2 transforms is to rewrite the expr in a not necessarily 'simpler' form.
+        if isinstance(t, (RewritePythagorean, RewriteTrig)):
             return False
         return node.expr.simplify() != node.expr
     def forward(self, node: Node) -> None:

--- a/src/simpy/transforms.py
+++ b/src/simpy/transforms.py
@@ -95,7 +95,8 @@ class Node:
     
     @property
     def is_stale(self) -> bool:
-        return not self.is_solved and any(parent.is_solved for parent in _parents(self))
+        """Stale = unfinished node that is no longer needed"""
+        return not self.is_finished and any(parent.is_finished for parent in _parents(self))
 
     @property
     def is_solved(self) -> bool:

--- a/src/simpy/utils.py
+++ b/src/simpy/utils.py
@@ -1,10 +1,11 @@
 import random
 import string
-from typing import Callable
+from typing import Callable, Optional
 
 from .expr import Expr
 
 ExprFn = Callable[[Expr], Expr]
+OptionalExprFn = Callable[[Expr], Optional[Expr]]
 
 def random_id(length):
     # Define the pool of characters you can choose from

--- a/src/simpy/utils.py
+++ b/src/simpy/utils.py
@@ -7,6 +7,7 @@ from .expr import Expr
 ExprFn = Callable[[Expr], Expr]
 OptionalExprFn = Callable[[Expr], Optional[Expr]]
 
+
 def random_id(length):
     # Define the pool of characters you can choose from
     characters = string.ascii_letters + string.digits

--- a/test_derivatives.py
+++ b/test_derivatives.py
@@ -5,7 +5,7 @@ from test_utils import assert_eq_strict, assert_eq_value, x, y
 def assert_diff(a: Expr, b: Expr):
     assert_eq_value(diff(a, x), b) # sometimes requires expand.
 
-def assert_diff_(a: Expr, b: Const, c: Const):
+def assert_diff_(a: Expr, b: Rat, c: Rat):
     ans = diff(a, x).evalf({"x": b})
     assert_eq_strict(ans, c)
 

--- a/test_derivatives.py
+++ b/test_derivatives.py
@@ -6,7 +6,7 @@ def assert_diff(a: Expr, b: Expr):
     assert_eq_value(diff(a, x), b) # sometimes requires expand.
 
 def assert_diff_(a: Expr, b: Rat, c: Rat):
-    ans = diff(a, x).evalf({"x": b})
+    ans = diff(a, x).subs({"x": b})
     assert_eq_strict(ans, c)
 
 

--- a/test_derivatives.py
+++ b/test_derivatives.py
@@ -3,7 +3,8 @@ from test_utils import assert_eq_strict, assert_eq_value, x, y
 
 
 def assert_diff(a: Expr, b: Expr):
-    assert_eq_value(diff(a, x), b) # sometimes requires expand.
+    assert_eq_value(diff(a, x), b)  # sometimes requires expand.
+
 
 def assert_diff_(a: Expr, b: Rat, c: Rat):
     ans = diff(a, x).subs({"x": b})
@@ -11,22 +12,23 @@ def assert_diff_(a: Expr, b: Rat, c: Rat):
 
 
 def test_basic_differentiation():
-    assert_diff(2 ** x, log(2) * 2 ** x)
-    assert_diff(x ** 7, 7 * x ** 6)
-    assert_diff(log(x), 1/x)
-    
+    assert_diff(2**x, log(2) * 2**x)
+    assert_diff(x**7, 7 * x**6)
+    assert_diff(log(x), 1 / x)
+
+
 def test_kh_derivatives():
-    assert_diff_(cot(x), 5*pi/3, Fraction(-4, 3))
+    assert_diff_(cot(x), 5 * pi / 3, Fraction(-4, 3))
     assert_diff_(sec(x), 0, 0)
-    assert_diff_(tan(x), 2*pi/3, 4)
-    assert_diff_(sec(x), 11*pi/6, -Fraction(2,3))
-    assert_diff_(csc(x), pi/2, 0)
-    assert_diff_(csc(x), 3*pi/4, sqrt(2))
+    assert_diff_(tan(x), 2 * pi / 3, 4)
+    assert_diff_(sec(x), 11 * pi / 6, -Fraction(2, 3))
+    assert_diff_(csc(x), pi / 2, 0)
+    assert_diff_(csc(x), 3 * pi / 4, sqrt(2))
 
-    assert_diff(-4*e**x-sin(x)-9, -4*e**x - cos(x))
-    assert_diff(-4*x**3-sin(x), -cos(x) - 12*x**2)
-    assert_diff(sqrt(x)*e**x, e**x/(2*sqrt(x)) + sqrt(x)*e**x)
-    assert_diff(cos(x)/log(x), (-x*sin(x)*log(x)-cos(x))/(x*log(x)**2))
-    assert_diff(sin(x)/e**x, (cos(x)-sin(x))/e**x)
+    assert_diff(-4 * e**x - sin(x) - 9, -4 * e**x - cos(x))
+    assert_diff(-4 * x**3 - sin(x), -cos(x) - 12 * x**2)
+    assert_diff(sqrt(x) * e**x, e**x / (2 * sqrt(x)) + sqrt(x) * e**x)
+    assert_diff(cos(x) / log(x), (-x * sin(x) * log(x) - cos(x)) / (x * log(x) ** 2))
+    assert_diff(sin(x) / e**x, (cos(x) - sin(x)) / e**x)
 
-    assert_diff(sec(y**3 * pi)/ 4, 0)
+    assert_diff(sec(y**3 * pi) / 4, 0)

--- a/test_expand_power.py
+++ b/test_expand_power.py
@@ -5,8 +5,8 @@ from test_utils import assert_eq_strict, unhashable_set_eq
 
 def test_expand_power():
     x = symbols("x")
-    power = (x ** 3 + 1) ** 6
-    prod = Prod([Sum([x ** 3, 1])]*6)
+    power = (x**3 + 1) ** 6
+    prod = Prod([Sum([x**3, 1])] * 6)
 
     assert_eq_strict(power.expand(), prod.expand())
 
@@ -15,7 +15,7 @@ def test_multinomial_powers():
 
     # Example usage
     i = 3  # Number of terms
-    n = 3 # Sum of terms
+    n = 3  # Sum of terms
     result = generate_permutations(i, n)
     expected_result = [
         [0, 0, 3],
@@ -27,7 +27,7 @@ def test_multinomial_powers():
         [1, 2, 0],
         [2, 0, 1],
         [2, 1, 0],
-        [3, 0, 0]
+        [3, 0, 0],
     ]
 
     # lmao this is a bit sad but it works

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -106,28 +106,33 @@ def test_repr():
     expr = 1 - x**2
     assert expr.__repr__() == "-x^2 + 1"
     assert repr(x - 2) == "x - 2"
-    assert (2 * x).__repr__() == "2x"
-    assert (2 * (2 + x)).__repr__() == "2(x + 2)"
+    assert (2 * x).__repr__() == "2*x"
+    assert (2 * (2 + x)).__repr__() == "2*(x + 2)"
     assert (2 / (2 + x)).__repr__() == "2/(x + 2)"
     assert repr(2 * (2 + x) ** (-2)) == repr(2 / (2 + x) ** 2) == "2/(x + 2)^2"
-    assert repr(Rat(-1) ** Fraction(1, 3)) == "(-1)^(1/3)"
+    assert repr(Rat(-1) ** Fraction(1, 4)) == "(-1)^(1/4)"
     assert sqrt(3).__repr__() == "sqrt(3)"
     assert repr(1 / sqrt(1 - x**2)) == "1/sqrt(-x^2 + 1)"
     assert repr(sqrt(1/x)) == "1/sqrt(x)"
     assert repr(x ** -Fraction(1,2)) == "1/sqrt(x)"
 
     # make sure denominator is bracketed
-    assert repr(sin(x) / (2 * x)) == "sin(x)/(2x)"
+    assert repr(sin(x) / (2 * x)) == "sin(x)/(2*x)"
     # make sure products with negative consts and dividing by consts are treated better
     assert repr(x / 2) == "x/2"
     assert repr(x * Fraction(1, 2)) == "x/2"
-    assert repr(3 - 2 * x) == "-2x + 3"
-    # make sure consts show up before pi
-    assert repr(pi * 2) == "2pi"
-    assert repr(pi * -2) == "-2pi"
+    assert repr(3 - 2 * x) == "-2*x + 3"
     # make sure polynomials show up in the correct order
     poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 - x ** 2
-    assert repr(poly) == "x^5 + 3x^4/2 - x^2 + 2x + 3"
+    assert repr(poly) == "x^5 + 3*x^4/2 - x^2 + 2*x + 3"
+
+    # when there are multiple symboless terms, make sure their order is logical
+    assert repr(2 + log(2)) == "ln(2) + 2"
+    assert repr(Rat(2, 3) ** Rat(2, 3) * -1) == "-(2/3)^(2/3)"
+    assert repr(Float(2.2) * Rat(3) * x) == "3*2.2*x"
+    # make sure consts show up before pi
+    assert repr(pi * 2) == "2*pi"
+    assert repr(pi * -2) == "-2*pi"
 
 
 def test_neg_power():

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -32,7 +32,7 @@ def test_equality():
 
 
 def test_floats():
-    assert_eq_strict(Float(3.2), Rat(16, 5))
+    assert_eq_strict(Float(3.2), Rat(16, 5).evalf())
     assert_eq_strict(Sum([Float(2.32), Float(.31)]), Float(2.63))
     assert_eq_strict(Prod([Float(2.32), Float(.31)]), Float(0.7192))
 
@@ -132,7 +132,6 @@ def test_repr():
 
 def test_neg_power():
     expr = Rat(-1) ** Fraction(5, 2) # this is i. ig it should just stay this way & not simplify.
-    breakpoint()
     assert debug_repr(expr) == "Power(-1, 5/2)"
 
 
@@ -338,6 +337,7 @@ def test_is_subtraction():
     assert (e ** x).is_subtraction is False
     assert (-e ** -x).is_subtraction is True
     assert (Rat(-3) ** 3).is_subtraction is True
-    assert (Rat(Fraction(-3, 2)) ** Fraction(2, 3)).is_subtraction is True
+    assert (Rat(Fraction(-3, 2)) ** Fraction(1, 3)).is_subtraction is True
     assert (Rat(Fraction(-3, 2)) ** Fraction(-2, 3)).is_subtraction is True
+    assert (Rat(Fraction(-3, 2)) ** Fraction(1, 2)).is_subtraction is False
 

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -322,16 +322,25 @@ def test_trigfuncs_auto_simplify_plus_2pis():
 def test_trigfuncs_auto_simplify_more_complex_negs():
     assert_eq_strict(cos(-x-2), cos(x+2))
 
-@pytest.mark.xfail
-def test_trigfunctions_special_values_are_correct():
-    # doesn't work rn because no decimals.
-    import math
 
+@pytest.mark.parametrize(["cls", "func"], [
+    [sin, math.sin],
+    [cos, math.cos],
+    [tan, math.tan],
+])
+def test_trigfunctions_special_values_are_correct(cls: Type[TrigFunction], func):
     import numpy as np
     for k in TrigFunction._SPECIAL_KEYS:
         num = Fraction(k)
-        np.testing.assert_almost_equal(sin(num*pi).value, math.sin(num*math.pi))
-        assert sin(num * pi) == math.sin(num * math.pi)
+        v1 = cls(num*pi).evalf().value
+        v2 = func(num*math.pi)
+        try:
+            np.testing.assert_almost_equal(v1, v2)
+        except AssertionError:
+            if cls == tan and (v1 == inf or v1 == -inf):
+                assert v2 > 1e10 or v2 < -1e-10
+            else:
+                raise AssertionError
 
 
 def test_is_subtraction():

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -31,7 +31,10 @@ def test_equality():
     assert cos(x * 2) == cos(x * 2)
 
 
-def test_basic_simplification():
+def test_defaults():
+    assert Sum([]) == 0
+    assert Prod([]) == 1
+
     assert_eq_strict(x * 0, 0)
     assert_eq_strict(x * 2, 2 * x)
     assert_eq_strict(x**2, x * x)
@@ -70,6 +73,9 @@ def test_expand_prod():
     # make sure that a numberator with a single sum gets expanded
     assert_eq_strict(((2 + x) / sin(x)).expand(), (2 / sin(x) + x / sin(x)))
 
+def test_expand_neg_power():
+    expr = (cos(2*x) + 1)**2 - 8/(3*(cos(2*x) + 1)**3) + 2/(cos(2*x) + 1)**-4
+    assert expr.expandable()
 
 def test_flatten():
     assert_eq_strict(x + (2 + y), x + 2 + y)
@@ -112,7 +118,7 @@ def test_repr():
     assert repr(pi * 2) == "2pi"
     assert repr(pi * -2) == "-2pi"
     # make sure polynomials show up in the correct order
-    poly = x ** 5 + 3 * x ** 4 / 2 + x ** 2 + 2 * x + 3
+    poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 + x ** 2
     assert repr(poly) == "x^5 + 3x^4/2 + x^2 + 2x + 3"
 
 @pytest.mark.xfail

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -303,3 +303,16 @@ def test_trigfunctions_special_values_are_correct():
         num = Fraction(k)
         np.testing.assert_almost_equal(sin(num*pi).value, math.sin(num*math.pi))
         assert sin(num * pi) == math.sin(num * math.pi)
+
+
+def test_is_subtraction():
+    assert x.is_subtraction is False
+    assert (-x).is_subtraction is True
+    assert Const(0).is_subtraction is False
+    assert Const(-2).is_subtraction is True 
+    assert (e ** x).is_subtraction is False
+    assert (-e ** -x).is_subtraction is True
+    assert (Const(-3) ** 3).is_subtraction is True
+    assert (Const(Fraction(-3, 2)) ** Fraction(2, 3)).is_subtraction is True
+    assert (Const(Fraction(-3, 2)) ** Fraction(-2, 3)).is_subtraction is True
+

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -20,15 +20,21 @@ def test_equality():
     assert x * y == y * x
 
     # consts should handle equality, inequality, greater than, less than
-    assert Const(2) == 2
-    assert Const(2) != 3
-    assert 2 == Const(2)
-    assert 2 < Const(3)
-    assert 2 <= Const(2)
-    assert Const(2) == Const(2)
+    assert Rat(2) == 2
+    assert Rat(2) != 3
+    assert 2 == Rat(2)
+    assert 2 < Rat(3)
+    assert 2 <= Rat(2)
+    assert Rat(2) == Rat(2)
 
     # trig functions aren't dataclasses so this is more liable to not working
     assert cos(x * 2) == cos(x * 2)
+
+
+def test_floats():
+    assert_eq_strict(Float(3.2), Rat(16, 5))
+    assert_eq_strict(Sum([Float(2.32), Float(.31)]), Float(2.63))
+    assert_eq_strict(Prod([Float(2.32), Float(.31)]), Float(0.7192))
 
 
 def test_defaults():
@@ -60,7 +66,7 @@ def test_prod_combines_like_terms_prod():
 def test_basic_power_simplification():
     assert_eq_strict(x**0, 1)
     assert_eq_strict(x**1, x)
-    assert_eq_strict(Const(2) ** 2, 4)
+    assert_eq_strict(Rat(2) ** 2, 4)
     assert_eq_strict(sqrt(4), 2)
     assert_eq_strict(sqrt(x**2), x)
     assert_eq_strict(2/sqrt(2), sqrt(2))
@@ -104,7 +110,7 @@ def test_repr():
     assert (2 * (2 + x)).__repr__() == "2(x + 2)"
     assert (2 / (2 + x)).__repr__() == "2/(x + 2)"
     assert repr(2 * (2 + x) ** (-2)) == repr(2 / (2 + x) ** 2) == "2/(x + 2)^2"
-    assert repr(Const(-1) ** Fraction(1, 3)) == "(-1)^(1/3)"
+    assert repr(Rat(-1) ** Fraction(1, 3)) == "(-1)^(1/3)"
     assert sqrt(3).__repr__() == "sqrt(3)"
     assert repr(1 / sqrt(1 - x**2)) == "1/sqrt(-x^2 + 1)"
     assert repr(sqrt(1/x)) == "1/sqrt(x)"
@@ -125,18 +131,18 @@ def test_repr():
 
 
 def test_neg_power():
-    expr = Const(-1) ** Fraction(5, 2) # this is i. ig it should just stay this way & not simplify.
+    expr = Rat(-1) ** Fraction(5, 2) # this is i. ig it should just stay this way & not simplify.
     breakpoint()
     assert debug_repr(expr) == "Power(-1, 5/2)"
 
 
 @pytest.mark.xfail
 def test_circular_repr():
-    expr = Const(-1) ** Fraction(5, 2) * -2
+    expr = Rat(-1) ** Fraction(5, 2) * -2
     repr(expr)
-    expr = Prod([-Fraction(4, 5), Const(-1)**Fraction(5, 2)])
+    expr = Prod([-Fraction(4, 5), Rat(-1)**Fraction(5, 2)])
     repr(expr)
-    expr = Prod([-Fraction(4, 5), Const(-1)**Fraction(5, 2)*x**Fraction(5,2)])
+    expr = Prod([-Fraction(4, 5), Rat(-1)**Fraction(5, 2)*x**Fraction(5,2)])
     repr(expr)
 
 
@@ -191,68 +197,68 @@ def test_factor_const():
 
 def test_strict_const_power_simplification():
     """TBH I feel like I made this overly complicated LOL but whatever we live with this."""
-    half = Const(Fraction(1, 2))
-    neg_half = Const(Fraction(-1, 2))
+    half = Rat(Fraction(1, 2))
+    neg_half = Rat(Fraction(-1, 2))
 
     # All permutations of (3/4)^(1/2)
-    expr = Power(Const(Fraction(3, 4)), half)
+    expr = Power(Rat(Fraction(3, 4)), half)
     expected = Prod([Power(3, half), half])
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(Fraction(4, 3)), half)
-    expected = Prod([Const(2), Power(3, neg_half)])
+    expr = Power(Rat(Fraction(4, 3)), half)
+    expected = Prod([Rat(2), Power(3, neg_half)])
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(Fraction(3, 4)), neg_half)
-    expected = Prod([Power(3, neg_half), Const(2)])
+    expr = Power(Rat(Fraction(3, 4)), neg_half)
+    expected = Prod([Power(3, neg_half), Rat(2)])
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(Fraction(4, 3)), neg_half)
+    expr = Power(Rat(Fraction(4, 3)), neg_half)
     expected = Prod([half, Power(3, half)])
     assert_eq_strict(expr, expected)
 
     # If the base is negative, it cannot square root.
-    expr = Power(Const(Fraction(-4, 3)), half)
-    expected = Power(Const(Fraction(-4, 3)), half)
+    expr = Power(Rat(Fraction(-4, 3)), half)
+    expected = Power(Rat(Fraction(-4, 3)), half)
     assert_eq_strict(expr, expected)
 
     # but it can cube root
-    expr = Power(Const(Fraction(-8, 3)), Fraction(1,3))
-    expected = Prod([Const(-2), Power(3, Fraction(-1,3))])
+    expr = Power(Rat(Fraction(-8, 3)), Fraction(1,3))
+    expected = Prod([Rat(-2), Power(3, Fraction(-1,3))])
     assert_eq_strict(expr, expected)
-    expr = Power(Const(Fraction(-8, 3)), Fraction(-1,3))
+    expr = Power(Rat(Fraction(-8, 3)), Fraction(-1,3))
     expected = Prod([neg_half, Power(3, Fraction(1,3))])
     assert_eq_strict(expr, expected)
 
 
     # All permutations of (36)^(1/2)
-    expr = Power(Const(Fraction(1, 36)), neg_half)
-    expected = Const(6)
+    expr = Power(Rat(Fraction(1, 36)), neg_half)
+    expected = Rat(6)
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(36), neg_half)
-    expected = Const(Fraction(1, 6))
+    expr = Power(Rat(36), neg_half)
+    expected = Rat(Fraction(1, 6))
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(36), half)
-    expected = Const(6)
+    expr = Power(Rat(36), half)
+    expected = Rat(6)
     assert_eq_strict(expr, expected)
 
-    expr = Power(Const(Fraction(1, 36)), half)
-    expected = Const(Fraction(1, 6))
+    expr = Power(Rat(Fraction(1, 36)), half)
+    expected = Rat(Fraction(1, 6))
     assert_eq_strict(expr, expected)
 
     # Nothing should happen when it's unsimplifiable
     # (this might change in the future bc maybe i want standards for frac^(neg x) vs reciprocal_frac^abs(neg x))
-    expr = Power(Const(2), neg_half)
+    expr = Power(Rat(2), neg_half)
     assert debug_repr(expr) == "Power(2, -1/2)"
 
     # This is the expression that caused me problems!!
     # When I was doing it wrong (raising numerator/denominator of Fraction to exponent seperately even when it was 1),
     # Power(Power(2, 1/2), -1) gets simplified to Prod(Power(Power(2, 1/2), -1), 1)
     # Which is the most bullshit ever.
-    expr = Power(Power(Const(2), half), -1)
-    expected = Power(Const(2), neg_half)
+    expr = Power(Power(Rat(2), half), -1)
+    expected = Power(Rat(2), neg_half)
     assert_eq_strict(expr, expected)
 
 
@@ -265,25 +271,25 @@ def test_fractional_power_beauty_standards():
 
     This keeps the repr standard consistent with Power(a, neg x) which is equal.
     """
-    f53 = Const(Fraction(5, 3))
-    f35 = Const(Fraction(3, 5))
-    half = Const(Fraction(1, 2))
-    neg_half = Const(Fraction(-1, 2))
+    f53 = Rat(Fraction(5, 3))
+    f35 = Rat(Fraction(3, 5))
+    half = Rat(Fraction(1, 2))
+    neg_half = Rat(Fraction(-1, 2))
 
     assert_eq_strict(f53 ** half, f35 ** neg_half) # [B]
     assert_eq_strict(f35 ** half, f53 ** neg_half) # [B]
 
     assert repr(Power(half, neg_half)) == "sqrt(2)" # [A]
-    assert_eq_strict(Power(half, neg_half), Power(Const(2), half)) # [A]
-    f17 = Const(Fraction(1, 7))
-    neg_f17 = Const(Fraction(-1, 7))
+    assert_eq_strict(Power(half, neg_half), Power(Rat(2), half)) # [A]
+    f17 = Rat(Fraction(1, 7))
+    neg_f17 = Rat(Fraction(-1, 7))
     assert repr(Power(half, neg_f17)) == "2^(1/7)" # [A]
     assert repr(Power(f17, neg_f17)) == "7^(1/7)" # [A]
 
     # More controversially, [C]:
     # Both of the following should be represented as 1/3^(1/7)
-    e1 = Power(Const(Fraction(1,3)), f17)
-    e2 = Power(Const(3), neg_f17)
+    e1 = Power(Rat(Fraction(1,3)), f17)
+    e2 = Power(Rat(3), neg_f17)
     assert repr(e1) == repr(e2) == "1/3^(1/7)"
     assert_eq_strict(e1, e2)
 
@@ -327,11 +333,11 @@ def test_trigfunctions_special_values_are_correct():
 def test_is_subtraction():
     assert x.is_subtraction is False
     assert (-x).is_subtraction is True
-    assert Const(0).is_subtraction is False
-    assert Const(-2).is_subtraction is True 
+    assert Rat(0).is_subtraction is False
+    assert Rat(-2).is_subtraction is True 
     assert (e ** x).is_subtraction is False
     assert (-e ** -x).is_subtraction is True
-    assert (Const(-3) ** 3).is_subtraction is True
-    assert (Const(Fraction(-3, 2)) ** Fraction(2, 3)).is_subtraction is True
-    assert (Const(Fraction(-3, 2)) ** Fraction(-2, 3)).is_subtraction is True
+    assert (Rat(-3) ** 3).is_subtraction is True
+    assert (Rat(Fraction(-3, 2)) ** Fraction(2, 3)).is_subtraction is True
+    assert (Rat(Fraction(-3, 2)) ** Fraction(-2, 3)).is_subtraction is True
 

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -123,9 +123,20 @@ def test_repr():
     poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 - x ** 2
     assert repr(poly) == "x^5 + 3x^4/2 - x^2 + 2x + 3"
 
+
+def test_neg_power():
+    expr = Const(-1) ** Fraction(5, 2) # this is i. ig it should just stay this way & not simplify.
+    breakpoint()
+    assert debug_repr(expr) == "Power(-1, 5/2)"
+
+
 @pytest.mark.xfail
 def test_circular_repr():
     expr = Const(-1) ** Fraction(5, 2) * -2
+    repr(expr)
+    expr = Prod([-Fraction(4, 5), Const(-1)**Fraction(5, 2)])
+    repr(expr)
+    expr = Prod([-Fraction(4, 5), Const(-1)**Fraction(5, 2)*x**Fraction(5,2)])
     repr(expr)
 
 

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -99,6 +99,7 @@ def test_repr():
     # New repr standards!!!
     expr = 1 - x**2
     assert expr.__repr__() == "-x^2 + 1"
+    assert repr(x - 2) == "x - 2"
     assert (2 * x).__repr__() == "2x"
     assert (2 * (2 + x)).__repr__() == "2(x + 2)"
     assert (2 / (2 + x)).__repr__() == "2/(x + 2)"

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -10,11 +10,11 @@ from test_utils import assert_eq_strict, unhashable_set_eq, x, y
 
 def test_equality():
     assert x == x
-    assert x == Symbol("x") # seperately created symbols with the same name should be the same
+    assert x == Symbol("x")  # seperately created symbols with the same name should be the same
     assert not x == y
     assert x != y
     assert not x == 2 * x
-    assert (x + 2) == (x + 2) # seperately created sums should be the same
+    assert (x + 2) == (x + 2)  # seperately created sums should be the same
     assert (x + 2) == (2 + x)
     assert x + 2 == Symbol("x") + 2
     assert x * y == y * x
@@ -33,8 +33,8 @@ def test_equality():
 
 def test_floats():
     assert_eq_strict(Float(3.2), Rat(16, 5).evalf())
-    assert_eq_strict(Sum([Float(2.32), Float(.31)]), Float(2.63))
-    assert_eq_strict(Prod([Float(2.32), Float(.31)]), Float(0.7192))
+    assert_eq_strict(Sum([Float(2.32), Float(0.31)]), Float(2.63))
+    assert_eq_strict(Prod([Float(2.32), Float(0.31)]), Float(0.7192))
 
 
 def test_defaults():
@@ -47,19 +47,21 @@ def test_defaults():
     assert_eq_strict(x * 2 - 2 * x, 0)
     assert_eq_strict(((x + 1) ** 2 - (x + 1) * (x + 1)), 0)
 
+
 def test_sum_combines_like_terms():
     assert_eq_strict(x + x, 2 * x)
     assert_eq_strict(x + x + x, 3 * x)
-    assert_eq_strict(3 * (x + 2) + 2 * (x + 2), 5 * (x + 2)) # like terms that is a sum
-    assert_eq_strict(3 * (x + 2) + 2 * (2 + x), 5 * (x + 2)) # like terms that is a sum
-    
+    assert_eq_strict(3 * (x + 2) + 2 * (x + 2), 5 * (x + 2))  # like terms that is a sum
+    assert_eq_strict(3 * (x + 2) + 2 * (2 + x), 5 * (x + 2))  # like terms that is a sum
+
+
 def test_prod_combines_like_terms_prod():
     assert_eq_strict(x**2, x * x)
     assert_eq_strict(x**3, x * x * x)
 
     # More complicated example
     # this wasn't working when the denominator "power" wasn't flattening in simplification.
-    expr = (2*sin(x)*cos(x)**2)/(sin(x)*cos(x)**2)
+    expr = (2 * sin(x) * cos(x) ** 2) / (sin(x) * cos(x) ** 2)
     assert expr == 2, f"expected 2, got {expr} // debug repr: {debug_repr(expr)}"
 
 
@@ -69,31 +71,35 @@ def test_basic_power_simplification():
     assert_eq_strict(Rat(2) ** 2, 4)
     assert_eq_strict(sqrt(4), 2)
     assert_eq_strict(sqrt(x**2), x)
-    assert_eq_strict(2/sqrt(2), sqrt(2))
+    assert_eq_strict(2 / sqrt(2), sqrt(2))
 
 
 def test_expand_prod():
     # make sure an expandable denominator gets expanded
-    assert_eq_strict((1 / (x * (x + 6))).expand(), 1 / (x**2 + x * 6)) # this can be converted to a power
+    assert_eq_strict((1 / (x * (x + 6))).expand(), 1 / (x**2 + x * 6))  # this can be converted to a power
     assert_eq_strict((y / (x * (x + 6))).expand(), y / (x**2 + x * 6))
     # make sure that a numberator with a single sum gets expanded
     assert_eq_strict(((2 + x) / sin(x)).expand(), (2 / sin(x) + x / sin(x)))
 
+
 def test_expand_neg_power():
-    expr = (cos(2*x) + 1)**2 - 8/(3*(cos(2*x) + 1)**3) + 2/(cos(2*x) + 1)**-4
+    expr = (cos(2 * x) + 1) ** 2 - 8 / (3 * (cos(2 * x) + 1) ** 3) + 2 / (cos(2 * x) + 1) ** -4
     assert expr.expandable()
+
 
 def test_flatten():
     assert_eq_strict(x + (2 + y), x + 2 + y)
 
     # Test nested flatten
-    expr = x ** 5 + ((3 + x) + 2 * y)
-    expected_terms = [x **5, 3, x, 2 * y]
+    expr = x**5 + ((3 + x) + 2 * y)
+    expected_terms = [x**5, 3, x, 2 * y]
     assert unhashable_set_eq(expr.terms, expected_terms)
+
 
 def test_regex():
     assert count(2, x) == 0
     assert count(tan(x + 1) ** 2 - 2 * x, x) == 2
+
 
 def test_nesting():
     assert nesting(x**2, x) == 2
@@ -113,8 +119,8 @@ def test_repr():
     assert repr(Rat(-1) ** Fraction(1, 4)) == "(-1)^(1/4)"
     assert sqrt(3).__repr__() == "sqrt(3)"
     assert repr(1 / sqrt(1 - x**2)) == "1/sqrt(-x^2 + 1)"
-    assert repr(sqrt(1/x)) == "1/sqrt(x)"
-    assert repr(x ** -Fraction(1,2)) == "1/sqrt(x)"
+    assert repr(sqrt(1 / x)) == "1/sqrt(x)"
+    assert repr(x ** -Fraction(1, 2)) == "1/sqrt(x)"
 
     # make sure denominator is bracketed
     assert repr(sin(x) / (2 * x)) == "sin(x)/(2*x)"
@@ -123,7 +129,7 @@ def test_repr():
     assert repr(x * Fraction(1, 2)) == "x/2"
     assert repr(3 - 2 * x) == "-2*x + 3"
     # make sure polynomials show up in the correct order
-    poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 - x ** 2
+    poly = 3 * x**4 / 2 + x**5 + 2 * x + 3 - x**2
     assert repr(poly) == "x^5 + 3*x^4/2 - x^2 + 2*x + 3"
 
     # when there are multiple symboless terms, make sure their order is logical
@@ -136,7 +142,7 @@ def test_repr():
 
 
 def test_neg_power():
-    expr = Rat(-1) ** Fraction(5, 2) # this is i. ig it should just stay this way & not simplify.
+    expr = Rat(-1) ** Fraction(5, 2)  # this is i. ig it should just stay this way & not simplify.
     assert debug_repr(expr) == "Power(-1, 5/2)"
 
 
@@ -144,16 +150,16 @@ def test_neg_power():
 def test_circular_repr():
     expr = Rat(-1) ** Fraction(5, 2) * -2
     repr(expr)
-    expr = Prod([-Fraction(4, 5), Rat(-1)**Fraction(5, 2)])
+    expr = Prod([-Fraction(4, 5), Rat(-1) ** Fraction(5, 2)])
     repr(expr)
-    expr = Prod([-Fraction(4, 5), Rat(-1)**Fraction(5, 2)*x**Fraction(5,2)])
+    expr = Prod([-Fraction(4, 5), Rat(-1) ** Fraction(5, 2) * x ** Fraction(5, 2)])
     repr(expr)
 
 
 def test_factor():
     # Simple example
     x = symbols("x")
-    expr = 6 * x + x **2 
+    expr = 6 * x + x**2
     expected = x * (x + 6)
     assert expr.factor() == expected
 
@@ -166,11 +172,7 @@ def test_factor():
         - c4 * r4 / (sqrt(a) * b ** Fraction(3 / 2))
     )
     factored = em_hw_expr.factor()
-    expected_factored = (
-        1
-        / (sqrt(a) * sqrt(b))
-        * (c3 * r3 - c3**2 * r3**2 / (c4 * r4 * a) - c4 * r4 / b)
-    )
+    expected_factored = 1 / (sqrt(a) * sqrt(b)) * (c3 * r3 - c3**2 * r3**2 / (c4 * r4 * a) - c4 * r4 / b)
     assert_eq_strict(factored, expected_factored)
 
 
@@ -189,15 +191,15 @@ def test_some_constructor_simplification():
     i_0 = v / z_eq
     pload = Fraction(1, 2) * r_l * i_0**2
 
-    assert_eq_strict(
-        pload, v**2 / (8 * r1)
-    )  # the power dissipated through the load when z_l = conjugate(z_s)
+    assert_eq_strict(pload, v**2 / (8 * r1))  # the power dissipated through the load when z_l = conjugate(z_s)
+
 
 def test_factor_const():
     expr = 2 - 2 * x
     factored = expr.factor()
     expected = 2 * (1 - x)
     assert_eq_strict(expected, factored)
+
 
 def test_strict_const_power_simplification():
     """TBH I feel like I made this overly complicated LOL but whatever we live with this."""
@@ -227,13 +229,12 @@ def test_strict_const_power_simplification():
     assert_eq_strict(expr, expected)
 
     # but it can cube root
-    expr = Power(Rat(Fraction(-8, 3)), Fraction(1,3))
-    expected = Prod([Rat(-2), Power(3, Fraction(-1,3))])
+    expr = Power(Rat(Fraction(-8, 3)), Fraction(1, 3))
+    expected = Prod([Rat(-2), Power(3, Fraction(-1, 3))])
     assert_eq_strict(expr, expected)
-    expr = Power(Rat(Fraction(-8, 3)), Fraction(-1,3))
-    expected = Prod([neg_half, Power(3, Fraction(1,3))])
+    expr = Power(Rat(Fraction(-8, 3)), Fraction(-1, 3))
+    expected = Prod([neg_half, Power(3, Fraction(1, 3))])
     assert_eq_strict(expr, expected)
-
 
     # All permutations of (36)^(1/2)
     expr = Power(Rat(Fraction(1, 36)), neg_half)
@@ -280,60 +281,66 @@ def test_fractional_power_beauty_standards():
     half = Rat(Fraction(1, 2))
     neg_half = Rat(Fraction(-1, 2))
 
-    assert_eq_strict(f53 ** half, f35 ** neg_half) # [B]
-    assert_eq_strict(f35 ** half, f53 ** neg_half) # [B]
+    assert_eq_strict(f53**half, f35**neg_half)  # [B]
+    assert_eq_strict(f35**half, f53**neg_half)  # [B]
 
-    assert repr(Power(half, neg_half)) == "sqrt(2)" # [A]
-    assert_eq_strict(Power(half, neg_half), Power(Rat(2), half)) # [A]
+    assert repr(Power(half, neg_half)) == "sqrt(2)"  # [A]
+    assert_eq_strict(Power(half, neg_half), Power(Rat(2), half))  # [A]
     f17 = Rat(Fraction(1, 7))
     neg_f17 = Rat(Fraction(-1, 7))
-    assert repr(Power(half, neg_f17)) == "2^(1/7)" # [A]
-    assert repr(Power(f17, neg_f17)) == "7^(1/7)" # [A]
+    assert repr(Power(half, neg_f17)) == "2^(1/7)"  # [A]
+    assert repr(Power(f17, neg_f17)) == "7^(1/7)"  # [A]
 
     # More controversially, [C]:
     # Both of the following should be represented as 1/3^(1/7)
-    e1 = Power(Rat(Fraction(1,3)), f17)
+    e1 = Power(Rat(Fraction(1, 3)), f17)
     e2 = Power(Rat(3), neg_f17)
     assert repr(e1) == repr(e2) == "1/3^(1/7)"
     assert_eq_strict(e1, e2)
 
+
 def test_singlefuncs_auto_simplify_special_values():
     assert_eq_strict(log(1), 0)
     assert_eq_strict(log(e**x), x)
-    assert_eq_strict(sin(3*pi), 0)
-    assert_eq_strict(cos(5*pi), -1)
-    assert_eq_strict(csc(pi/2), 1)
-    assert_eq_strict(cot(pi/4), 1)
+    assert_eq_strict(sin(3 * pi), 0)
+    assert_eq_strict(cos(5 * pi), -1)
+    assert_eq_strict(csc(pi / 2), 1)
+    assert_eq_strict(cot(pi / 4), 1)
     assert_eq_strict(cos(-x), cos(x))
     assert_eq_strict(sin(-x), -sin(x))
     assert_eq_strict(tan(-x), -tan(x))
-    assert_eq_strict(sin(acos(x+y)), sqrt(1 - (x+y)**2))
-    assert_eq_strict(csc(acos(x+y)), 1/sqrt(1 - (x+y)**2))
-    assert_eq_strict(sec(acos(x+y)), 1/(x+y))
-    assert_eq_strict(atan(cot(3*x+2)), 1/(3*x+2))
+    assert_eq_strict(sin(acos(x + y)), sqrt(1 - (x + y) ** 2))
+    assert_eq_strict(csc(acos(x + y)), 1 / sqrt(1 - (x + y) ** 2))
+    assert_eq_strict(sec(acos(x + y)), 1 / (x + y))
+    assert_eq_strict(atan(cot(3 * x + 2)), 1 / (3 * x + 2))
 
 
 @pytest.mark.xfail
 def test_trigfuncs_auto_simplify_plus_2pis():
-    assert_eq_strict(cos(x + 2*pi), cos(x))
-    assert_eq_strict(sin(x + e ** y + 4*pi), sin(x + e ** y))
-    assert_eq_strict(asin(x + 2*pi), asin(x + 2*pi))
+    assert_eq_strict(cos(x + 2 * pi), cos(x))
+    assert_eq_strict(sin(x + e**y + 4 * pi), sin(x + e**y))
+    assert_eq_strict(asin(x + 2 * pi), asin(x + 2 * pi))
+
 
 def test_trigfuncs_auto_simplify_more_complex_negs():
-    assert_eq_strict(cos(-x-2), cos(x+2))
+    assert_eq_strict(cos(-x - 2), cos(x + 2))
 
 
-@pytest.mark.parametrize(["cls", "func"], [
-    [sin, math.sin],
-    [cos, math.cos],
-    [tan, math.tan],
-])
+@pytest.mark.parametrize(
+    ["cls", "func"],
+    [
+        [sin, math.sin],
+        [cos, math.cos],
+        [tan, math.tan],
+    ],
+)
 def test_trigfunctions_special_values_are_correct(cls: Type[TrigFunction], func):
     import numpy as np
+
     for k in TrigFunction._SPECIAL_KEYS:
         num = Fraction(k)
-        v1 = cls(num*pi).evalf().value
-        v2 = func(num*math.pi)
+        v1 = cls(num * pi).evalf().value
+        v2 = func(num * math.pi)
         try:
             np.testing.assert_almost_equal(v1, v2)
         except AssertionError:
@@ -347,11 +354,10 @@ def test_is_subtraction():
     assert x.is_subtraction is False
     assert (-x).is_subtraction is True
     assert Rat(0).is_subtraction is False
-    assert Rat(-2).is_subtraction is True 
-    assert (e ** x).is_subtraction is False
-    assert (-e ** -x).is_subtraction is True
+    assert Rat(-2).is_subtraction is True
+    assert (e**x).is_subtraction is False
+    assert (-(e**-x)).is_subtraction is True
     assert (Rat(-3) ** 3).is_subtraction is True
     assert (Rat(Fraction(-3, 2)) ** Fraction(1, 3)).is_subtraction is True
     assert (Rat(Fraction(-3, 2)) ** Fraction(-2, 3)).is_subtraction is True
     assert (Rat(Fraction(-3, 2)) ** Fraction(1, 2)).is_subtraction is False
-

--- a/test_exprs.py
+++ b/test_exprs.py
@@ -104,6 +104,7 @@ def test_repr():
     assert (2 * (2 + x)).__repr__() == "2(x + 2)"
     assert (2 / (2 + x)).__repr__() == "2/(x + 2)"
     assert repr(2 * (2 + x) ** (-2)) == repr(2 / (2 + x) ** 2) == "2/(x + 2)^2"
+    assert repr(Const(-1) ** Fraction(1, 3)) == "(-1)^(1/3)"
     assert sqrt(3).__repr__() == "sqrt(3)"
     assert repr(1 / sqrt(1 - x**2)) == "1/sqrt(-x^2 + 1)"
     assert repr(sqrt(1/x)) == "1/sqrt(x)"
@@ -119,8 +120,8 @@ def test_repr():
     assert repr(pi * 2) == "2pi"
     assert repr(pi * -2) == "-2pi"
     # make sure polynomials show up in the correct order
-    poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 + x ** 2
-    assert repr(poly) == "x^5 + 3x^4/2 + x^2 + 2x + 3"
+    poly = 3 * x ** 4 / 2 + x ** 5 + 2 * x + 3 - x ** 2
+    assert repr(poly) == "x^5 + 3x^4/2 - x^2 + 2x + 3"
 
 @pytest.mark.xfail
 def test_circular_repr():

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -86,7 +86,10 @@ def test_linear_usub_with_multiple_subs():
     integral = integrate(integrand)
     assert integral == expected or integral == expected2
 
+import pytest
 
+
+@pytest.mark.xfail
 def test_misc():
     # This integral can either be sin^2(wt) / 2w or -cos^2(wt) / 2w depending on the method used to solve it
     w, t = symbols("w t")

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.simpy.expr import *
 from src.simpy.integration import *
 from test_utils import (
@@ -33,6 +35,9 @@ def test_stat_polynomials():
     assert (I1, I2, I3) == (F(23, 378000), F(2589, 56000), F(37, 224))
 
 
+# this also timeouts sometimes in CI
+# we really have to improve speed
+@pytest.mark.xfail
 def test_lecture_example():
     """The integral from the MIT OCW lecture that inspired this project:
     https://ocw.mit.edu/courses/6-034-artificial-intelligence-fall-2010/resources/lecture-2-reasoning-goal-trees-and-problem-solving/

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -107,6 +107,11 @@ def test_misc():
     ans = integrate(integrand, x)
     assert ans is None
 
+    # we used to get this wrong from a byparts error
+    integrand = cos(x)*cos(2*x)
+    expected_ans = 2 * cos(x) * sin(2*x)/3 - sin(x)*cos(2*x)/3
+    assert_integral(integrand, expected_ans)
+
 
 def test_integrate_with_completing_the_square():
     expr = 1 / sqrt(- x ** 2 + 10 * x + 11)

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -81,7 +81,7 @@ def test_linear_usub_with_multiple_subs():
     # Last I checked, this fails without LinearUSub
     integrand = sin(2*x) / cos(2*x)
     expected = -log(abs(cos(2*x)))/2
-    expected2 = log(abs(sec(2*x)**2))/4
+    expected2 = log(abs(sec(2*x)))/2
     # can't fucking implement this being equal. wtv.
     integral = integrate(integrand)
     assert integral == expected or integral == expected2

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -1,42 +1,46 @@
 from src.simpy.expr import *
 from src.simpy.integration import *
-from test_utils import (assert_definite_integral, assert_eq_plusc,
-                        assert_eq_strict, assert_eq_value, assert_integral, x,
-                        y)
+from test_utils import (
+    assert_definite_integral,
+    assert_eq_plusc,
+    assert_eq_strict,
+    assert_eq_value,
+    assert_integral,
+    x,
+    y,
+)
 
 F = Fraction
 x = symbols("x")
 
+
 def test_basic_integrals():
     assert_definite_integral(2, (x, 5, 3), -4)
-    assert_integral(x ** Fraction(7, 3), Fraction(3, 10) * x ** Fraction(10,3))
+    assert_integral(x ** Fraction(7, 3), Fraction(3, 10) * x ** Fraction(10, 3))
     assert_integral(3 * x**2 - 2 * x, x**3 - x**2)
     assert_integral((x + 1) ** 2, x + x**2 + (x**3 / 3))
-    assert_integral(x ** 12, x ** 13 / 13)
+    assert_integral(x**12, x**13 / 13)
     assert_integral(1 / x, log(abs(x)))
     assert_definite_integral(1 / x, (x, 1, 2), log(2))
     assert_integral(y, x * y, var=x)
     assert_integral(tan(y), x * tan(y), var=x)
 
-def test_stat_polynomials():
-    I1 = integrate((x/90 * (x-5)**2 / 350), (x, 5, 6))
-    I2 = integrate((F(1, 15) - F(1, 360) * (x-6))*(x-5)**2 / 350, (x, 6, 15))
-    I3 = integrate((F(1, 15) - F(1, 360) * (x-6))*(1 - (40-x)**2/875), (x, 15, 30))
-    assert (I1, I2, I3) == (F(23,378000), F(2589,56000), F(37,224))
 
-    
+def test_stat_polynomials():
+    I1 = integrate((x / 90 * (x - 5) ** 2 / 350), (x, 5, 6))
+    I2 = integrate((F(1, 15) - F(1, 360) * (x - 6)) * (x - 5) ** 2 / 350, (x, 6, 15))
+    I3 = integrate((F(1, 15) - F(1, 360) * (x - 6)) * (1 - (40 - x) ** 2 / 875), (x, 15, 30))
+    assert (I1, I2, I3) == (F(23, 378000), F(2589, 56000), F(37, 224))
+
+
 def test_lecture_example():
     """The integral from the MIT OCW lecture that inspired this project:
     https://ocw.mit.edu/courses/6-034-artificial-intelligence-fall-2010/resources/lecture-2-reasoning-goal-trees-and-problem-solving/
-    
+
     Highly recommend watching this to understand how this program performs integrals.
     """
     expression = -5 * x**4 / (1 - x**2) ** F(5, 2)
-    expected_integral = -5 * (
-        -(x / (sqrt(1 - x**2)))
-        + (F(1, 3) * x**3 / (1 - x**2) ** F(3, 2))
-        + asin(x)
-    )
+    expected_integral = -5 * (-(x / (sqrt(1 - x**2))) + (F(1, 3) * x**3 / (1 - x**2) ** F(3, 2)) + asin(x))
     assert_integral(expression, expected_integral)
 
 
@@ -50,6 +54,7 @@ def test_x2_sqrt_1_x3():
     expression = x**2 / sqrt(1 - x**3)
     expected = -2 * sqrt(1 - x**3) / 3
     assert_integral(expression, expected)
+
 
 def test_compound_angle():
     # Finds the average power of an AC circuit
@@ -77,11 +82,12 @@ def test_cos2x():
     expected = sin(2 * x) / 4 + x / 2
     assert_integral(expr, expected)
 
+
 def test_linear_usub_with_multiple_subs():
     # Last I checked, this fails without LinearUSub
-    integrand = sin(2*x) / cos(2*x)
-    expected = -log(abs(cos(2*x)))/2
-    expected2 = log(abs(sec(2*x)))/2
+    integrand = sin(2 * x) / cos(2 * x)
+    expected = -log(abs(cos(2 * x))) / 2
+    expected2 = log(abs(sec(2 * x))) / 2
     # can't fucking implement this being equal. wtv.
     integral = integrate(integrand)
     assert integral == expected or integral == expected2
@@ -99,37 +105,37 @@ def test_misc():
     assert_integral(log(x), x * log(x) - x)
 
     integrand = log(x + 6) / x**2
-    expected = log(abs(x)) / 6 - log(x + 6) / x - log(abs(x+6)) / 6 # TODO: why does one of them not have abs?
+    expected = log(abs(x)) / 6 - log(x + 6) / x - log(abs(x + 6)) / 6  # TODO: why does one of them not have abs?
     assert_integral(integrand, expected)
 
     # without the string search fix on InverseTrigUSub, this returns a wrong answer.
-    integrand = sqrt(x ** 2 + 11)
+    integrand = sqrt(x**2 + 11)
     ans = integrate(integrand, x)
     assert ans is None
 
     # we used to get this wrong from a byparts error
-    integrand = cos(x)*cos(2*x)
-    expected_ans = 2 * cos(x) * sin(2*x)/3 - sin(x)*cos(2*x)/3
-    expected_ans_2 = (sin(3*x)/3 + sin(x))/2
+    integrand = cos(x) * cos(2 * x)
+    expected_ans = 2 * cos(x) * sin(2 * x) / 3 - sin(x) * cos(2 * x) / 3
+    expected_ans_2 = (sin(3 * x) / 3 + sin(x)) / 2
     # these 2 answers are exactly equivalent but i literally can't even see why.
     ans = integrate(integrand)
     assert ans == expected_ans or ans == expected_ans_2
 
 
 def test_integrate_with_completing_the_square():
-    expr = 1 / sqrt(- x ** 2 + 10 * x + 11)
+    expr = 1 / sqrt(-(x**2) + 10 * x + 11)
     expected = asin((x - 5) / 6)
     assert_integral(expr, expected)
 
 
-def integrate_polar(r: Expr, theta: Symbol, a=0, b=2*pi) -> Expr:
-    return integrate(r ** 2, (theta, a, b)) / 2
+def integrate_polar(r: Expr, theta: Symbol, a=0, b=2 * pi) -> Expr:
+    return integrate(r**2, (theta, a, b)) / 2
+
 
 def test_area_between():
     theta = symbols("theta")
     r1 = 3 * sin(theta)
     r2 = 1 + sin(theta)
-    bounds = (pi/6, 5 * pi / 6)
+    bounds = (pi / 6, 5 * pi / 6)
     ans = integrate_polar(r1, theta, *bounds) - integrate_polar(r2, theta, *bounds)
     assert_eq_value(ans, pi)
-

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -86,10 +86,7 @@ def test_linear_usub_with_multiple_subs():
     integral = integrate(integrand)
     assert integral == expected or integral == expected2
 
-import pytest
 
-
-@pytest.mark.xfail
 def test_misc():
     # This integral can either be sin^2(wt) / 2w or -cos^2(wt) / 2w depending on the method used to solve it
     w, t = symbols("w t")

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -110,7 +110,10 @@ def test_misc():
     # we used to get this wrong from a byparts error
     integrand = cos(x)*cos(2*x)
     expected_ans = 2 * cos(x) * sin(2*x)/3 - sin(x)*cos(2*x)/3
-    assert_integral(integrand, expected_ans)
+    expected_ans_2 = (sin(3*x)/3 + sin(x))/2
+    # these 2 answers are exactly equivalent but i literally can't even see why.
+    ans = integrate(integrand)
+    assert ans == expected_ans or ans == expected_ans_2
 
 
 def test_integrate_with_completing_the_square():

--- a/test_integrals.py
+++ b/test_integrals.py
@@ -35,9 +35,6 @@ def test_stat_polynomials():
     assert (I1, I2, I3) == (F(23, 378000), F(2589, 56000), F(37, 224))
 
 
-# this also timeouts sometimes in CI
-# we really have to improve speed
-@pytest.mark.xfail
 def test_lecture_example():
     """The integral from the MIT OCW lecture that inspired this project:
     https://ocw.mit.edu/courses/6-034-artificial-intelligence-fall-2010/resources/lecture-2-reasoning-goal-trees-and-problem-solving/

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -99,14 +99,10 @@ def test_misc():
     assert_definite_integral(8 * x / sqrt(1 - 4 * x ** 2), (0, Fraction(1,4)), 2 - sqrt(3))
     assert_definite_integral(sin(4*x), (0, pi/4), Fraction(1,2))
 
-@pytest.mark.xfail
 def test_csc_x_squared():
-    # idk how to simplify the answer to this one.
-    # requires simplifying 1/sinxcosx - tanx -> cotx ??
-
-    # takes forever
     integrand = 5 * csc(x) ** 2
-    expected_ans = -5 * cot(x)
+    # expected_ans = -5 * cot(x) # dream of this
+    expected_ans = 1/(cos(x)*sin(x)) - tan(x)
     assert_integral(integrand, expected_ans)
 
 def test_csc_x_cot_x():
@@ -156,16 +152,6 @@ def test_bigger_power_trig():
 
 def test_rewrite_pythag():
     expr = sin(x) ** 2 * cos(x) ** 3
-    ## USED TO
-    # returns the right answer, just with a tree 27 layers deep and with a very long expression
-    # probs assert equality by implemeting product-to-sum and compound angle?? which one tho? we can experiment.
-    # sin(x)cos(4x)/120 + sin(x)cos(2x)/12 - cos(x)sin(4x)/30 - cos(x)sin(2x)/6 - sin(x)^3/6 + 3sin(x)/8
-    ## USED TO
-    # ^ im proud this no longer happens <3 i didnt even optimize for it; i just made the changes to
-    # changing depth first to breadth first when expression became too complicated <3
-    # and this happend as a bypproduct!
-    # this means that the decision was a good architectural decision; not a narrow patch that only fixes that one specific case.
-    
     # this one still takes ~.9s to complete, which is quite long & much longer than any other integral in our tests as of 05/10.
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
     assert_integral(expr, expected_ans)
@@ -180,10 +166,7 @@ def test_tan_x_4():
     assert_eq_value(ans, pi/4 - Fraction(2,3))
 
 
-@pytest.mark.xfail
 def test_more_complicated_trig():
     expr = tan(x) ** 5 * sec(x) ** 4
     expected_ans = tan(x) ** 6 / 6 + tan(x) ** 8 / 8
     assert_integral(expr, expected_ans)
-    # the answer is the correct value but it does not simplify it to the expected answer
-    # 1/(4cos(x)^4) - 1/(3cos(x)^6) + 1/(8cos(x)^8)

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -74,8 +74,7 @@ def test_arcsin():
     assert_eq_plusc(ans, expected_ans)
 
     ans = integrate(atan(x), x)
-    # expected_ans = x * atan(x) - log(abs(1 + x**2)) / 2 # TODO: can't make this equal
-    expected_ans = x * atan(x) + log(abs(1/sqrt(x**2 + 1)))
+    expected_ans = x * atan(x) - log(abs(1 + x**2)) / 2
     assert_eq_plusc(ans, expected_ans)
 
 

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -109,7 +109,6 @@ def test_csc_x_squared():
     expected_ans = -5 * cot(x)
     assert_integral(integrand, expected_ans)
 
-@pytest.mark.xfail
 def test_csc_x_cot_x():
     # this one requires simpy knowing that 1/sin(x) and csc(x) are the same
     integrand = 2 * csc(x) * cot(x)

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -151,16 +151,25 @@ def test_neg_inf():
 def test_bigger_power_trig():
     # uses product-to-sum on bigger powers:
     expr = sin(x) ** 4
-    ans = integrate(expr)
+    expected = (sin(4*x) - 8*sin(2*x) + 12*x) / 32
+    assert_integral(expr, expected)
 
 
 def test_rewrite_pythag():
-    expr2 = sin(x) ** 2 * cos(x) ** 3
-    ans2 = integrate(expr2)
+    expr = sin(x) ** 2 * cos(x) ** 3
+    ## USED TO
     # returns the right answer, just with a tree 27 layers deep and with a very long expression
     # probs assert equality by implemeting product-to-sum and compound angle?? which one tho? we can experiment.
     # sin(x)cos(4x)/120 + sin(x)cos(2x)/12 - cos(x)sin(4x)/30 - cos(x)sin(2x)/6 - sin(x)^3/6 + 3sin(x)/8
+    ## USED TO
+    # ^ im proud this no longer happens <3 i didnt even optimize for it; i just made the changes to
+    # changing depth first to breadth first when expression became too complicated <3
+    # and this happend as a bypproduct!
+    # this means that the decision was a good architectural decision; not a narrow patch that only fixes that one specific case.
+    
+    # this one still takes ~.9s to complete, which is quite long & much longer than any other integral in our tests as of 05/10.
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
+    assert_integral(expr, expected_ans)
 
     assert_integral(sin(x)**3, cos(x)**3/3 - cos(x))
     assert_integral(cos(x)**5, sin(x)**5/5 - 2*sin(x)**3/3 + sin(x))
@@ -168,14 +177,14 @@ def test_rewrite_pythag():
 def test_tan_x_4():
     # this would take forever if i don't have node.add_child 
     # when sin^4x/cos^4x on the first one, it never goes onto the inversetrigusub.
-
-    # this still takes a long time ngl but does not loop to hell.
     ans = integrate(tan(x)**4, (0, pi/4))
     assert_eq_value(ans, pi/4 - Fraction(2,3))
 
 
+@pytest.mark.xfail
 def test_more_complicated_trig():
     expr = tan(x) ** 5 * sec(x) ** 4
-    ans = integrate(expr) # 1/(4cos(x)^4) - 1/(3cos(x)^6) + 1/(8cos(x)^8)
     expected_ans = tan(x) ** 6 / 6 + tan(x) ** 8 / 8
+    assert_integral(expr, expected_ans)
     # the answer is the correct value but it does not simplify it to the expected answer
+    # 1/(4cos(x)^4) - 1/(3cos(x)^6) + 1/(8cos(x)^8)

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -143,6 +143,5 @@ def test_complete_the_square_integrals():
     assert_integral(1/sqrt(-x**2-6*x+40), asin((3 + x)/7))
 
 
-@pytest.mark.xfail
 def test_neg_inf():
     assert integrate(-e ** x, (-oo, 1)) == -e

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -155,9 +155,6 @@ def test_bigger_power_trig():
     assert_integral(expr, expected)
 
 
-# This passes locally but times out in the CI
-# TODO to look into it in depth later.
-@pytest.mark.xfail
 def test_rewrite_pythag():
     expr = sin(x) ** 2 * cos(x) ** 3
     # this one still takes ~.9s to complete, which is quite long & much longer than any other integral in our tests as of 05/10.

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -37,7 +37,6 @@ def test_partial_fractions():
     assert_integral(integrand, expected_ans)
 
 
-@pytest.mark.xfail
 def test_integration_by_parts():
     integrand = x * e ** (-x)
     expected = -e ** (-x) * (x + 1)
@@ -65,7 +64,6 @@ def test_integration_by_parts():
     assert_integral(integrand, expected)
 
 
-@pytest.mark.xfail
 def test_arcsin():
     ans = integrate(asin(x), x)
     expected_ans = x * asin(x) + sqrt(1 - x**2)

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -125,10 +125,11 @@ def test_expanding_big_power():
     expected_ans = (1 + x**3)**7/7
     assert_integral(integrand, expected_ans)
 
-@pytest.mark.xfail
+
 def test_polynomial_div_integrals():
-    # TODO: investigate later
-    assert_integral((x-5) / (-2 * x + 2), - x / 2 + 2 * log(abs(1 - x)))
+    expr = (x-5) / (-2 * x + 2)
+    expected =  -x/2 + 2 * log(abs(1 - x))
+    assert_integral(expr, expected)
     assert_integral((x ** 3 - 1)/ (x+2), x**3/3 - x**2 + 4*x- 9*log(abs(2 + x)))
     assert_integral((x - 1)/ (2 * x + 4), x / 2 - Fraction(3, 2) * log(abs(x + 2)))
     

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -155,7 +155,6 @@ def test_bigger_power_trig():
 
 
 def test_rewrite_pythag():
-   
     expr2 = sin(x) ** 2 * cos(x) ** 3
     ans2 = integrate(expr2)
     # returns the right answer, just with a tree 27 layers deep and with a very long expression
@@ -163,8 +162,8 @@ def test_rewrite_pythag():
     # sin(x)cos(4x)/120 + sin(x)cos(2x)/12 - cos(x)sin(4x)/30 - cos(x)sin(2x)/6 - sin(x)^3/6 + 3sin(x)/8
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
 
-    expr = sin(x) ** 3
-    ans = integrate(expr)
+    assert_integral(sin(x)**3, cos(x)**3/3 - cos(x))
+    assert_integral(cos(x)**5, sin(x)**5/5 - 2*sin(x)**3/3 + sin(x))
 
 def test_tan_x_4():
     # this would take forever if i don't have node.add_child 

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -140,7 +140,7 @@ def test_complete_the_square_integrals():
 
 
 def test_neg_inf():
-    assert integrate(-e ** x, (-oo, 1)) == -e
+    assert integrate(-e ** x, (-inf, 1)) == -e
 
 
 def test_bigger_power_trig():

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -2,12 +2,19 @@
 LOL im gonna take a bunch of integral questions from https://www.khanacademy.org/math/integral-calculus/ic-integration/ic-integration-proofs/test/ic-integration-unit-
 and make sure simpy can do them
 """
+
 import pytest
 
 from src.simpy.expr import *
 from src.simpy.integration import *
-from test_utils import (assert_definite_integral, assert_eq_plusc,
-                        assert_eq_value, assert_integral, x, y)
+from test_utils import (
+    assert_definite_integral,
+    assert_eq_plusc,
+    assert_eq_value,
+    assert_integral,
+    x,
+    y,
+)
 
 
 def test_ex():
@@ -15,52 +22,54 @@ def test_ex():
     ans = integrate(integrand, (x, 6, 12))
     assert_eq_plusc(ans, 6 * e**12 - 6 * e**6)
 
+
 def test_xcosx():
     """Uses integration by parts"""
     integrand = x * cos(x)
     ans = integrate(integrand, (x, 3 * pi / 2, pi))
     assert_eq_plusc(ans, 3 * pi / 2 - 1)
 
+
 def test_partial_fractions():
     integrand = (x + 8) / (x * (x + 6))
     expected_ans = Fraction(4, 3) * log(abs(x)) - Fraction(1, 3) * log(abs(x + 6))
     assert_integral(integrand, expected_ans)
 
-    integrand = (18-12*x)/(4*x-1)/(x-4)
-    expected_ans = -log(abs(4*x-1))-2*log(abs(x-4))
+    integrand = (18 - 12 * x) / (4 * x - 1) / (x - 4)
+    expected_ans = -log(abs(4 * x - 1)) - 2 * log(abs(x - 4))
     assert_integral(integrand, expected_ans)
-    integrand = (2*x+3)/(x-3)/(x+3)
-    expected_ans = 3*log(abs(x-3))/2 + log(abs(x+3))/2
+    integrand = (2 * x + 3) / (x - 3) / (x + 3)
+    expected_ans = 3 * log(abs(x - 3)) / 2 + log(abs(x + 3)) / 2
     assert_integral(integrand, expected_ans)
-    integrand = (x-2)/(2*x+1)/(x+3)
-    expected_ans = -log(abs(2*x+1))/2 + log(abs(x+3))
+    integrand = (x - 2) / (2 * x + 1) / (x + 3)
+    expected_ans = -log(abs(2 * x + 1)) / 2 + log(abs(x + 3))
     assert_integral(integrand, expected_ans)
 
 
 def test_integration_by_parts():
     integrand = x * e ** (-x)
-    expected = -e ** (-x) * (x + 1)
+    expected = -(e ** (-x)) * (x + 1)
     assert_integral(integrand, expected)
 
-    integrand = log(x) / x ** 2
+    integrand = log(x) / x**2
     expected = -log(x) / x - 1 / x
     assert_integral(integrand, expected)
 
-    ans = integrate(x*sqrt(x-y), (x, 0, y))
+    ans = integrate(x * sqrt(x - y), (x, 0, y))
     assert ans == Fraction(4, 15) * (-y) ** Fraction(5, 2)
 
-    integrand =  x * e ** (4*x)
-    assert_definite_integral(integrand, (0, 2), Fraction(7, 16) * e ** 8 + Fraction(1, 16))
+    integrand = x * e ** (4 * x)
+    assert_definite_integral(integrand, (0, 2), Fraction(7, 16) * e**8 + Fraction(1, 16))
 
-    assert_definite_integral(-x * cos(x), (pi/2, pi), 1 + pi/2)
+    assert_definite_integral(-x * cos(x), (pi / 2, pi), 1 + pi / 2)
 
     # Challenge questions
-    integrand = e ** x * sin(x)
-    expected = e ** x / 2 * (sin(x) - cos(x))
+    integrand = e**x * sin(x)
+    expected = e**x / 2 * (sin(x) - cos(x))
     assert_integral(integrand, expected)
 
-    integrand = x ** 2 * sin(pi * x) 
-    expected = -x**2 * cos(pi * x) / pi + 2 * x * sin(pi*x) / pi ** 2 + 2*cos(pi*x)/pi**3
+    integrand = x**2 * sin(pi * x)
+    expected = -(x**2) * cos(pi * x) / pi + 2 * x * sin(pi * x) / pi**2 + 2 * cos(pi * x) / pi**3
     assert_integral(integrand, expected)
 
 
@@ -80,30 +89,33 @@ def test_arcsin():
 
 def test_sec2x_tan2x():
     """Uses either integration by parts with direct solve or generic sin/cos usub"""
-    integrand = sec(2*x) * tan(2*x)
-    ans = integrate(integrand, (x, 0, pi/6))
+    integrand = sec(2 * x) * tan(2 * x)
+    ans = integrate(integrand, (x, 0, pi / 6))
     assert ans == Fraction(1, 2)
+
 
 def test_misc():
     assert_integral(4 * sec(x) ** 2, 4 * tan(x))
     assert_integral(sec(x) ** 2 * tan(x) ** 2, tan(x) ** 3 / 3)
-    assert_integral(5 / x - 3 * e ** x, 5 * log(abs(x)) - 3 * e ** x)
-    assert_integral(sec(x), log(sec(x) + tan(x))) # TODO: should this be abs?
-    assert_integral(2 * cos(2 * x - 5), sin(2 * x - 5)) 
-    assert_integral(3 * x ** 5 - x ** 3 + 6, 6*x - x**4/4 + x**6/2)
-    assert_integral(x ** 3 * e ** (x ** 4), (e**(x**4)/4))
+    assert_integral(5 / x - 3 * e**x, 5 * log(abs(x)) - 3 * e**x)
+    assert_integral(sec(x), log(sec(x) + tan(x)))  # TODO: should this be abs?
+    assert_integral(2 * cos(2 * x - 5), sin(2 * x - 5))
+    assert_integral(3 * x**5 - x**3 + 6, 6 * x - x**4 / 4 + x**6 / 2)
+    assert_integral(x**3 * e ** (x**4), (e ** (x**4) / 4))
 
     # Uses generic u-sub
-    assert_definite_integral(e ** x / (1 + e ** x), (log(2), log(8)), log(9) - log(3))
+    assert_definite_integral(e**x / (1 + e**x), (log(2), log(8)), log(9) - log(3))
 
-    assert_definite_integral(8 * x / sqrt(1 - 4 * x ** 2), (0, Fraction(1,4)), 2 - sqrt(3))
-    assert_definite_integral(sin(4*x), (0, pi/4), Fraction(1,2))
+    assert_definite_integral(8 * x / sqrt(1 - 4 * x**2), (0, Fraction(1, 4)), 2 - sqrt(3))
+    assert_definite_integral(sin(4 * x), (0, pi / 4), Fraction(1, 2))
+
 
 def test_csc_x_squared():
     integrand = 5 * csc(x) ** 2
     # expected_ans = -5 * cot(x) # dream of this
-    expected_ans = 1/(cos(x)*sin(x)) - tan(x)
+    expected_ans = 1 / (cos(x) * sin(x)) - tan(x)
     assert_integral(integrand, expected_ans)
+
 
 def test_csc_x_cot_x():
     # this one requires simpy knowing that 1/sin(x) and csc(x) are the same
@@ -114,39 +126,40 @@ def test_csc_x_cot_x():
 
 def test_expanding_big_power():
     integrand = (2 * x - 5) ** 10
-    expected_ans = (2*x-5)**11/22
+    expected_ans = (2 * x - 5) ** 11 / 22
     assert_integral(integrand, expected_ans)
 
-    integrand = 3 * x ** 2 * (x ** 3 + 1) ** 6
-    expected_ans = (1 + x**3)**7/7
+    integrand = 3 * x**2 * (x**3 + 1) ** 6
+    expected_ans = (1 + x**3) ** 7 / 7
     assert_integral(integrand, expected_ans)
 
 
 def test_polynomial_div_integrals():
-    expr = (x-5) / (-2 * x + 2)
-    expected =  -x/2 + 2 * log(abs(1 - x))
+    expr = (x - 5) / (-2 * x + 2)
+    expected = -x / 2 + 2 * log(abs(1 - x))
     assert_integral(expr, expected)
-    assert_integral((x ** 3 - 1)/ (x+2), x**3/3 - x**2 + 4*x- 9*log(abs(2 + x)))
-    assert_integral((x - 1)/ (2 * x + 4), x / 2 - Fraction(3, 2) * log(abs(x + 2)))
-    
-    integrand = (2 * x ** 3 + 4 * x ** 2 - 5)/ (x + 3)
+    assert_integral((x**3 - 1) / (x + 2), x**3 / 3 - x**2 + 4 * x - 9 * log(abs(2 + x)))
+    assert_integral((x - 1) / (2 * x + 4), x / 2 - Fraction(3, 2) * log(abs(x + 2)))
+
+    integrand = (2 * x**3 + 4 * x**2 - 5) / (x + 3)
     ans = integrate(integrand, x)
     # TODO: expected = ...
 
+
 def test_complete_the_square_integrals():
-    assert_integral(1/(3*x**2+6*x+78), atan((1 + x)/5)/15)
-    assert_integral(1/(x**2-8*x+65), atan((-4 + x)/7)/7)
-    assert_integral(1/sqrt(-x**2-6*x+40), asin((3 + x)/7))
+    assert_integral(1 / (3 * x**2 + 6 * x + 78), atan((1 + x) / 5) / 15)
+    assert_integral(1 / (x**2 - 8 * x + 65), atan((-4 + x) / 7) / 7)
+    assert_integral(1 / sqrt(-(x**2) - 6 * x + 40), asin((3 + x) / 7))
 
 
 def test_neg_inf():
-    assert integrate(-e ** x, (-inf, 1)) == -e
+    assert integrate(-(e**x), (-inf, 1)) == -e
 
 
 def test_bigger_power_trig():
     # uses product-to-sum on bigger powers:
     expr = sin(x) ** 4
-    expected = (sin(4*x) - 8*sin(2*x) + 12*x) / 32
+    expected = (sin(4 * x) - 8 * sin(2 * x) + 12 * x) / 32
     assert_integral(expr, expected)
 
 
@@ -156,14 +169,15 @@ def test_rewrite_pythag():
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
     assert_integral(expr, expected_ans)
 
-    assert_integral(sin(x)**3, cos(x)**3/3 - cos(x))
-    assert_integral(cos(x)**5, sin(x)**5/5 - 2*sin(x)**3/3 + sin(x))
+    assert_integral(sin(x) ** 3, cos(x) ** 3 / 3 - cos(x))
+    assert_integral(cos(x) ** 5, sin(x) ** 5 / 5 - 2 * sin(x) ** 3 / 3 + sin(x))
+
 
 def test_tan_x_4():
-    # this would take forever if i don't have node.add_child 
+    # this would take forever if i don't have node.add_child
     # when sin^4x/cos^4x on the first one, it never goes onto the inversetrigusub.
-    ans = integrate(tan(x)**4, (0, pi/4))
-    assert_eq_value(ans, pi/4 - Fraction(2,3))
+    ans = integrate(tan(x) ** 4, (0, pi / 4))
+    assert_eq_value(ans, pi / 4 - Fraction(2, 3))
 
 
 def test_more_complicated_trig():

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -155,12 +155,17 @@ def test_bigger_power_trig():
     assert_integral(expr, expected)
 
 
+# This passes locally but times out in the CI
+# TODO to look into it in depth later.
+@pytest.mark.xfail
 def test_rewrite_pythag():
     expr = sin(x) ** 2 * cos(x) ** 3
     # this one still takes ~.9s to complete, which is quite long & much longer than any other integral in our tests as of 05/10.
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
     assert_integral(expr, expected_ans)
 
+
+def test_rewrite_pythag_2():
     assert_integral(sin(x) ** 3, cos(x) ** 3 / 3 - cos(x))
     assert_integral(cos(x) ** 5, sin(x) ** 5 / 5 - 2 * sin(x) ** 3 / 3 + sin(x))
 

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -7,14 +7,7 @@ import pytest
 
 from src.simpy.expr import *
 from src.simpy.integration import *
-from test_utils import (
-    assert_definite_integral,
-    assert_eq_plusc,
-    assert_eq_value,
-    assert_integral,
-    x,
-    y,
-)
+from test_utils import assert_definite_integral, assert_eq_plusc, assert_eq_value, assert_integral, x, y
 
 
 def test_ex():
@@ -112,8 +105,7 @@ def test_misc():
 
 def test_csc_x_squared():
     integrand = 5 * csc(x) ** 2
-    # expected_ans = -5 * cot(x) # dream of this
-    expected_ans = 1 / (cos(x) * sin(x)) - tan(x)
+    expected_ans = -5 * cot(x)
     assert_integral(integrand, expected_ans)
 
 

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -37,6 +37,7 @@ def test_partial_fractions():
     assert_integral(integrand, expected_ans)
 
 
+@pytest.mark.xfail
 def test_integration_by_parts():
     integrand = x * e ** (-x)
     expected = -e ** (-x) * (x + 1)
@@ -64,6 +65,7 @@ def test_integration_by_parts():
     assert_integral(integrand, expected)
 
 
+@pytest.mark.xfail
 def test_arcsin():
     ans = integrate(asin(x), x)
     expected_ans = x * asin(x) + sqrt(1 - x**2)
@@ -103,9 +105,11 @@ def test_misc():
 def test_csc_x_squared():
     # idk how to simplify the answer to this one.
     # requires simplifying 1/sinxcosx - tanx -> cotx ??
+
+    # takes forever
     integrand = 5 * csc(x) ** 2
     expected_ans = -5 * cot(x)
-    assert_integral(integrand, expected_ans)
+    # assert_integral(integrand, expected_ans)
 
 @pytest.mark.xfail
 def test_csc_x_cot_x():
@@ -155,13 +159,19 @@ def test_bigger_power_trig():
 def test_rewrite_pythag():
    
     expr2 = sin(x) ** 2 * cos(x) ** 3
-    ans2 = integrate(expr2, verbose=True)
+    ans2 = integrate(expr2)
     # returns the right answer, just with a tree 27 layers deep and with a very long expression
     # probs assert equality by implemeting product-to-sum and compound angle?? which one tho? we can experiment.
     # sin(x)cos(4x)/120 + sin(x)cos(2x)/12 - cos(x)sin(4x)/30 - cos(x)sin(2x)/6 - sin(x)^3/6 + 3sin(x)/8
     expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
 
-    breakpoint()
     expr = sin(x) ** 3
     ans = integrate(expr)
 
+def test_tan_x_4():
+    # this would take forever if i don't have node.add_child 
+    # when sin^4x/cos^4x on the first one, it never goes onto the inversetrigusub.
+
+    # this still takes a long time ngl but does not loop to hell.
+    ans = integrate(tan(x)**4, (0, pi/4))
+    assert_eq_plusc(ans, pi/4 - Fraction(2,3))

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -145,3 +145,24 @@ def test_complete_the_square_integrals():
 
 def test_neg_inf():
     assert integrate(-e ** x, (-oo, 1)) == -e
+
+
+def test_bigger_power_trig():
+    # uses product-to-sum on bigger powers:
+    expr = sin(x) ** 4
+    ans = integrate(expr)
+
+
+def test_rewrite_pythag():
+   
+    expr2 = sin(x) ** 2 * cos(x) ** 3
+    ans2 = integrate(expr2, verbose=True)
+    # returns the right answer, just with a tree 27 layers deep and with a very long expression
+    # probs assert equality by implemeting product-to-sum and compound angle?? which one tho? we can experiment.
+    # sin(x)cos(4x)/120 + sin(x)cos(2x)/12 - cos(x)sin(4x)/30 - cos(x)sin(2x)/6 - sin(x)^3/6 + 3sin(x)/8
+    expected_ans = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
+
+    breakpoint()
+    expr = sin(x) ** 3
+    ans = integrate(expr)
+

--- a/test_khan_academy_integrals.py
+++ b/test_khan_academy_integrals.py
@@ -7,7 +7,7 @@ import pytest
 from src.simpy.expr import *
 from src.simpy.integration import *
 from test_utils import (assert_definite_integral, assert_eq_plusc,
-                        assert_integral, x, y)
+                        assert_eq_value, assert_integral, x, y)
 
 
 def test_ex():
@@ -109,7 +109,7 @@ def test_csc_x_squared():
     # takes forever
     integrand = 5 * csc(x) ** 2
     expected_ans = -5 * cot(x)
-    # assert_integral(integrand, expected_ans)
+    assert_integral(integrand, expected_ans)
 
 @pytest.mark.xfail
 def test_csc_x_cot_x():
@@ -174,4 +174,11 @@ def test_tan_x_4():
 
     # this still takes a long time ngl but does not loop to hell.
     ans = integrate(tan(x)**4, (0, pi/4))
-    assert_eq_plusc(ans, pi/4 - Fraction(2,3))
+    assert_eq_value(ans, pi/4 - Fraction(2,3))
+
+
+def test_more_complicated_trig():
+    expr = tan(x) ** 5 * sec(x) ** 4
+    ans = integrate(expr) # 1/(4cos(x)^4) - 1/(3cos(x)^6) + 1/(8cos(x)^8)
+    expected_ans = tan(x) ** 6 / 6 + tan(x) ** 8 / 8
+    # the answer is the correct value but it does not simplify it to the expected answer

--- a/test_nums.py
+++ b/test_nums.py
@@ -1,0 +1,19 @@
+from src.simpy.expr import *
+
+
+def test_infinity_basic_ops():
+    assert 0 < oo
+    assert Const(1) == 1
+    assert oo ** 1 == oo
+    assert oo == oo + 1
+    assert sqrt(oo) == oo
+    assert oo == 2*oo
+    assert 192330 < oo
+    assert oo > -oo
+    assert -oo < -2039
+    assert -oo == -oo - 1
+    assert -oo == -2*oo
+    
+def test_nums():
+    assert e > 2
+    assert pi <= 4

--- a/test_nums.py
+++ b/test_nums.py
@@ -4,16 +4,17 @@ from src.simpy.expr import *
 def test_infinity_basic_ops():
     assert 0 < inf
     assert Rat(1) == 1
-    assert inf ** 1 == inf
+    assert inf**1 == inf
     assert inf == inf + 1
     assert sqrt(inf) == inf
-    assert inf == 2*inf
+    assert inf == 2 * inf
     assert 192330 < inf
     assert inf > -inf
     assert -inf < -2039
     assert -inf == -inf - 1
-    assert -inf == -2*inf
-    
+    assert -inf == -2 * inf
+
+
 def test_nums():
     assert e > 2
     assert pi <= 4

--- a/test_nums.py
+++ b/test_nums.py
@@ -2,17 +2,17 @@ from src.simpy.expr import *
 
 
 def test_infinity_basic_ops():
-    assert 0 < oo
-    assert Const(1) == 1
-    assert oo ** 1 == oo
-    assert oo == oo + 1
-    assert sqrt(oo) == oo
-    assert oo == 2*oo
-    assert 192330 < oo
-    assert oo > -oo
-    assert -oo < -2039
-    assert -oo == -oo - 1
-    assert -oo == -2*oo
+    assert 0 < inf
+    assert Rat(1) == 1
+    assert inf ** 1 == inf
+    assert inf == inf + 1
+    assert sqrt(inf) == inf
+    assert inf == 2*inf
+    assert 192330 < inf
+    assert inf > -inf
+    assert -inf < -2039
+    assert -inf == -inf - 1
+    assert -inf == -2*inf
     
 def test_nums():
     assert e > 2

--- a/test_regex.py
+++ b/test_regex.py
@@ -15,11 +15,11 @@ def test_any_basic():
 @pytest.mark.parametrize(
     ["sum", "expected"],
     [
-        [tan(2 * x) ** 2 + 1, {"success": True, "factor": 1, "anyfind": 2 * x}],
-        [tan(2 * x + y) ** 2 + 1, {"success": True, "factor": 1, "anyfind": 2 * x + y}],
+        [tan(2 * x) ** 2 + 1, {"success": True, "factor": 1, "matches": 2 * x}],
+        [tan(2 * x + y) ** 2 + 1, {"success": True, "factor": 1, "matches": 2 * x + y}],
         [
             3 * tan(2 * x + y) ** 2 + 3,
-            {"success": True, "factor": 3, "anyfind": 2 * x + y},
+            {"success": True, "factor": 3, "matches": 2 * x + y},
         ],
     ],
 )
@@ -31,23 +31,23 @@ def test_up_to_factor_on_simple_examples():
     assert eq(tan(3), tan(3), up_to_factor=True) == {
         "success": True,
         "factor": 1,
-        "anyfind": {},
+        "matches": {},
     }
-    assert eq(x, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
+    assert eq(x, x, up_to_factor=True) == {"success": True, "factor": 1, "matches": {}}
     assert eq(tan(x), 3 * tan(any_), up_to_factor=True) == {
         "success": True,
         "factor": 3,
-        "anyfind": x,
+        "matches": x,
     }
 
     # Not implemented right now but shrug don't need it.
-    # assert eq(2, 3, up_to_factor=True) == {"success": True, "factor": Rat(3, 2), "anyfind": {}}
+    # assert eq(2, 3, up_to_factor=True) == {"success": True, "factor": Rat(3, 2), "matches": {}}
 
     # I need to set clearer rules with like what happens if there's an any * factor on the outside bracket
     # like it's unclearish. rn in anydivide the any can only catch one but what if it's both idk.
     # right now let's just let it fail LOL
-    # assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": x}
-    # assert eq(any_, x*2, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": 2*x}
+    # assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "matches": x}
+    # assert eq(any_, x*2, up_to_factor=True) == {"success": True, "factor": 1, "matches": 2*x}
 
 
 def test_factor_doesnt_overstep():
@@ -66,7 +66,7 @@ def test_up_to_sum():
     expr = -sin(x) ** 2 - 5 ** cos(x) ** 2 + 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_sum=True)
-    assert ans == {"success": True, "anyfind": x, "rest": -(5 ** cos(x) ** 2)}
+    assert ans == {"success": True, "matches": x, "rest": -(5 ** cos(x) ** 2)}
 
 
 def test_up_to_sum_and_factor():
@@ -75,7 +75,7 @@ def test_up_to_sum_and_factor():
     ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
     assert ans == {
         "success": True,
-        "anyfind": x,
+        "matches": x,
         "factor": -1,
         "rest": -(5 ** cos(x) ** 2),
     }

--- a/test_regex.py
+++ b/test_regex.py
@@ -6,7 +6,7 @@ from test_utils import x, y
 
 
 def test_any_basic():
-    assert not eq(Const(1), Const(-1))[0]
+    assert not eq(Rat(1), Rat(-1))[0]
     assert eq(sin(x), sin(any_))[0]
 
 

--- a/test_regex.py
+++ b/test_regex.py
@@ -82,7 +82,8 @@ def test_up_to_sum_and_factor():
 
 
 def test_cofounder():
-    # This shit was causing problems
+    # Tests that even if every query term individually has a match, it'll still be unsuccessful if we can't consolidate
+    # them to have the same values for each any.
     t, w = symbols("t w")
     expr = -sin(t * w) ** 2 - cos(t * w) ** 2
     query = -sin(any_) ** 2 + 1

--- a/test_regex.py
+++ b/test_regex.py
@@ -8,22 +8,37 @@ from test_utils import x, y
 def test_any_basic():
     assert not eq(Rat(1), Rat(-1))["success"]
     assert eq(sin(x), sin(any_))["success"]
-    assert eq(tan(x)**2, tan(any_)**2)["success"]
-    assert eq(tan(2*x)**2, tan(any_)**2)["success"]
+    assert eq(tan(x) ** 2, tan(any_) ** 2)["success"]
+    assert eq(tan(2 * x) ** 2, tan(any_) ** 2)["success"]
 
 
-@pytest.mark.parametrize(["sum", "expected"], [
-    [tan(2*x)**2 + 1, {"success": True, "factor": 1, "anyfind": 2*x}],
-    [tan(2*x+y)**2 + 1, {"success": True, "factor": 1, "anyfind": 2*x+y}],
-    [3*tan(2*x+y)**2 + 3, {"success": True, "factor": 3, "anyfind": 2*x+y}]
-])
+@pytest.mark.parametrize(
+    ["sum", "expected"],
+    [
+        [tan(2 * x) ** 2 + 1, {"success": True, "factor": 1, "anyfind": 2 * x}],
+        [tan(2 * x + y) ** 2 + 1, {"success": True, "factor": 1, "anyfind": 2 * x + y}],
+        [
+            3 * tan(2 * x + y) ** 2 + 3,
+            {"success": True, "factor": 3, "anyfind": 2 * x + y},
+        ],
+    ],
+)
 def test_any_tan(sum, expected):
     assert eq(sum, 1 + tan(any_) ** 2, up_to_factor=True) == expected
 
+
 def test_up_to_factor_on_simple_examples():
-    assert eq(tan(3), tan(3), up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
+    assert eq(tan(3), tan(3), up_to_factor=True) == {
+        "success": True,
+        "factor": 1,
+        "anyfind": {},
+    }
     assert eq(x, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
-    assert eq(tan(x), 3*tan(any_), up_to_factor=True) == {"success": True, "factor": 3, "anyfind": x}
+    assert eq(tan(x), 3 * tan(any_), up_to_factor=True) == {
+        "success": True,
+        "factor": 3,
+        "anyfind": x,
+    }
 
     # Not implemented right now but shrug don't need it.
     # assert eq(2, 3, up_to_factor=True) == {"success": True, "factor": Rat(3, 2), "anyfind": {}}
@@ -34,34 +49,42 @@ def test_up_to_factor_on_simple_examples():
     # assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": x}
     # assert eq(any_, x*2, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": 2*x}
 
+
 def test_factor_doesnt_overstep():
     assert not eq(1 + sin(x) ** 2, 1 + tan(any_) ** 2, up_to_factor=True)["success"]
 
 
 def test_unlimited_sum():
     expr = 2 + x + sin(x) ** 2 + cos(x) ** 2
-    query = sin(any_)**2 + cos(any_)**2
+    query = sin(any_) ** 2 + cos(any_) ** 2
     out = eq(expr, query, up_to_sum=True)
     assert out["success"]
     assert out["rest"] == 2 + x
 
 
 def test_up_to_sum():
-    expr = -sin(x)**2 - 5**cos(x)**2 + 1
+    expr = -sin(x) ** 2 - 5 ** cos(x) ** 2 + 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_sum=True)
-    assert ans == {"success": True, "anyfind": x, "rest": -5**cos(x)**2}
+    assert ans == {"success": True, "anyfind": x, "rest": -(5 ** cos(x) ** 2)}
+
 
 def test_up_to_sum_and_factor():
-    expr = sin(x)**2 - 5**cos(x)**2 - 1
+    expr = sin(x) ** 2 - 5 ** cos(x) ** 2 - 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
-    assert ans == {"success": True, "anyfind": x, "factor": -1, "rest": -5**cos(x)**2}
+    assert ans == {
+        "success": True,
+        "anyfind": x,
+        "factor": -1,
+        "rest": -(5 ** cos(x) ** 2),
+    }
+
 
 def test_cofounder():
     # This shit was causing problems
     t, w = symbols("t w")
-    expr = -sin(t*w)**2 - cos(t*w)**2
+    expr = -sin(t * w) ** 2 - cos(t * w) ** 2
     query = -sin(any_) ** 2 + 1
     out = eq(expr, query, up_to_factor=True, up_to_sum=True)
     assert out["success"] is False

--- a/test_regex.py
+++ b/test_regex.py
@@ -57,3 +57,11 @@ def test_up_to_sum_and_factor():
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
     assert ans == {"success": True, "anyfind": x, "factor": -1, "rest": -5**cos(x)**2}
+
+def test_cofounder():
+    # This shit was causing problems
+    t, w = symbols("t w")
+    expr = -sin(t*w)**2 - cos(t*w)**2
+    query = -sin(any_) ** 2 + 1
+    out = eq(expr, query, up_to_factor=True, up_to_sum=True)
+    assert out["success"] is False

--- a/test_regex.py
+++ b/test_regex.py
@@ -21,21 +21,29 @@ def test_any_tan(sum, expected):
     assert eq(sum, 1 + tan(any_) ** 2, up_to_factor=True) == expected
 
 def test_up_to_factor_on_simple_examples():
-    # assert eq(2, 3, True)
-    assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": x}
-    assert eq(any_, *2, up_to_factor=True) == {"success": True, "factor": 2, "anyfind": x}
     assert eq(tan(3), tan(3), up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
+    assert eq(x, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
     assert eq(tan(x), 3*tan(any_), up_to_factor=True) == {"success": True, "factor": 3, "anyfind": x}
+
+    # Not implemented right now but shrug don't need it.
+    # assert eq(2, 3, up_to_factor=True) == {"success": True, "factor": Rat(3, 2), "anyfind": {}}
+
+    # I need to set clearer rules with like what happens if there's an any * factor on the outside bracket
+    # like it's unclearish. rn in anydivide the any can only catch one but what if it's both idk.
+    # right now let's just let it fail LOL
+    # assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": x}
+    # assert eq(any_, x*2, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": 2*x}
 
 def test_factor_doesnt_overstep():
     assert not eq(1 + sin(x) ** 2, 1 + tan(any_) ** 2, up_to_factor=True)["success"]
 
-@pytest.mark.xfail
+
 def test_unlimited_sum():
     expr = 2 + x + sin(x) ** 2 + cos(x) ** 2
-    anyterms = Any_()
-    query = anyterms + sin(any_) + cos(any_)
-    assert eq(expr, query)["success"]
+    query = sin(any_)**2 + cos(any_)**2
+    out = eq(expr, query, up_to_sum=True)
+    assert out["success"]
+    assert out["rest"] == 2 + x
 
 
 def test_up_to_sum():
@@ -48,4 +56,4 @@ def test_up_to_sum_and_factor():
     expr = sin(x)**2 - 5**cos(x)**2 - 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
-    assert ans == {"success": True, "anyfind": x, "factor": -1, "rest": 5**cos(x)**2}
+    assert ans == {"success": True, "anyfind": x, "factor": -1, "rest": -5**cos(x)**2}

--- a/test_regex.py
+++ b/test_regex.py
@@ -1,8 +1,13 @@
 import pytest
 
-from src.simpy import *
+from src.simpy.expr import *
 from src.simpy.regex import Any_, any_, eq
 from test_utils import x, y
+
+
+def test_any_basic():
+    assert not eq(Const(1), Const(-1))[0]
+    assert eq(sin(x), sin(any_))[0]
 
 
 @pytest.mark.parametrize(["sum", "expected"], [
@@ -10,7 +15,7 @@ from test_utils import x, y
     [tan(2*x+y)**2 + 1, (True, 1, 2*x+y)],
     [3*tan(2*x+y)**2 + 3, (True, 3, 2*x+y)]
 ])
-def test_any(sum, expected):
+def test_any_tan(sum, expected):
     assert eq(sum, 1 + tan(any_) ** 2, True) == expected
 
 def test_up_to_factor_on_simple_examples():
@@ -29,3 +34,16 @@ def test_unlimited_sum():
     anyterms = Any_()
     query = anyterms + sin(any_) + cos(any_)
     assert eq(expr, query)[0]
+
+
+def test_up_to_sum():
+    expr = -sin(x)**2 - 5**cos(x)**2 + 1
+    query = 1 - sin(any_) ** 2
+    ans = eq(expr, query, up_to_sum=True)
+    assert ans == (True, x)
+
+def test_up_to_sum_and_factor():
+    expr = sin(x)**2 - 5**cos(x)**2 - 1
+    query = 1 - sin(any_) ** 2
+    ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
+    breakpoint()

--- a/test_regex.py
+++ b/test_regex.py
@@ -6,44 +6,46 @@ from test_utils import x, y
 
 
 def test_any_basic():
-    assert not eq(Rat(1), Rat(-1))[0]
-    assert eq(sin(x), sin(any_))[0]
+    assert not eq(Rat(1), Rat(-1))["success"]
+    assert eq(sin(x), sin(any_))["success"]
+    assert eq(tan(x)**2, tan(any_)**2)["success"]
+    assert eq(tan(2*x)**2, tan(any_)**2)["success"]
 
 
 @pytest.mark.parametrize(["sum", "expected"], [
-    [tan(2*x)**2 + 1, (True, 1, 2*x)],
-    [tan(2*x+y)**2 + 1, (True, 1, 2*x+y)],
-    [3*tan(2*x+y)**2 + 3, (True, 3, 2*x+y)]
+    [tan(2*x)**2 + 1, {"success": True, "factor": 1, "anyfind": 2*x}],
+    [tan(2*x+y)**2 + 1, {"success": True, "factor": 1, "anyfind": 2*x+y}],
+    [3*tan(2*x+y)**2 + 3, {"success": True, "factor": 3, "anyfind": 2*x+y}]
 ])
 def test_any_tan(sum, expected):
-    assert eq(sum, 1 + tan(any_) ** 2, True) == expected
+    assert eq(sum, 1 + tan(any_) ** 2, up_to_factor=True) == expected
 
 def test_up_to_factor_on_simple_examples():
     # assert eq(2, 3, True)
-    assert eq(x, x, True) == (True, 1, {})
-    assert eq(x, x*2, True) == (True, 2, {})
-    assert eq(tan(3), tan(3), True) == (True, 1, {})
-    assert eq(tan(x), 3*tan(x), True) == (True, 3, {})
+    assert eq(any_, x, up_to_factor=True) == {"success": True, "factor": 1, "anyfind": x}
+    assert eq(any_, *2, up_to_factor=True) == {"success": True, "factor": 2, "anyfind": x}
+    assert eq(tan(3), tan(3), up_to_factor=True) == {"success": True, "factor": 1, "anyfind": {}}
+    assert eq(tan(x), 3*tan(any_), up_to_factor=True) == {"success": True, "factor": 3, "anyfind": x}
 
 def test_factor_doesnt_overstep():
-    assert not eq(1 + sin(x) ** 2, 1 + tan(any_) ** 2, True)[0]
+    assert not eq(1 + sin(x) ** 2, 1 + tan(any_) ** 2, up_to_factor=True)["success"]
 
 @pytest.mark.xfail
 def test_unlimited_sum():
     expr = 2 + x + sin(x) ** 2 + cos(x) ** 2
     anyterms = Any_()
     query = anyterms + sin(any_) + cos(any_)
-    assert eq(expr, query)[0]
+    assert eq(expr, query)["success"]
 
 
 def test_up_to_sum():
     expr = -sin(x)**2 - 5**cos(x)**2 + 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_sum=True)
-    assert ans == (True, x)
+    assert ans == {"success": True, "anyfind": x, "rest": -5**cos(x)**2}
 
 def test_up_to_sum_and_factor():
     expr = sin(x)**2 - 5**cos(x)**2 - 1
     query = 1 - sin(any_) ** 2
     ans = eq(expr, query, up_to_factor=True, up_to_sum=True)
-    breakpoint()
+    assert ans == {"success": True, "anyfind": x, "factor": -1, "rest": 5**cos(x)**2}

--- a/test_transforms.py
+++ b/test_transforms.py
@@ -5,12 +5,16 @@ Ex doesn't rlly make sense to put test_complete_the_square not next to test_inte
 Don't want to disconnect code structure from meaning too much altho it's easy to get caught up in code structure :)
 """
 
-
 import numpy as np
 
 from src.simpy.expr import Rat
-from src.simpy.transforms import (CompleteTheSquare, Node, PolynomialDivision,
-                                  PullConstant, to_const_polynomial)
+from src.simpy.transforms import (
+    CompleteTheSquare,
+    Node,
+    PolynomialDivision,
+    PullConstant,
+    to_const_polynomial,
+)
 from test_utils import assert_eq_strict, x
 
 
@@ -24,7 +28,7 @@ def test_pullconstant():
 
 
 def test_to_polynomial():
-    expr = 6 * x + x **2 
+    expr = 6 * x + x**2
     assert np.array_equal(to_const_polynomial(expr, x), np.array([Rat(0), Rat(6), Rat(1)]))
 
 
@@ -48,11 +52,12 @@ def test_polynomial_division():
     tr.forward(test_node)
     ans = test_node.children[0].expr
 
+
 def test_complete_the_square():
-    quadratic = - x ** 2 + 10 * x + 11
+    quadratic = -(x**2) + 10 * x + 11
     test_node = Node(quadratic, x)
     tr = CompleteTheSquare()
     tr.forward(test_node)
     ans = test_node.child.expr
-    expected = 36 * (-(x - 5) ** 2  / 36 + 1)
+    expected = 36 * (-((x - 5) ** 2) / 36 + 1)
     assert_eq_strict(ans, expected)

--- a/test_transforms.py
+++ b/test_transforms.py
@@ -8,7 +8,7 @@ Don't want to disconnect code structure from meaning too much altho it's easy to
 
 import numpy as np
 
-from src.simpy.expr import Const
+from src.simpy.expr import Rat
 from src.simpy.transforms import (CompleteTheSquare, Node, PolynomialDivision,
                                   PullConstant, to_const_polynomial)
 from test_utils import assert_eq_strict, x
@@ -25,7 +25,7 @@ def test_pullconstant():
 
 def test_to_polynomial():
     expr = 6 * x + x **2 
-    assert np.array_equal(to_const_polynomial(expr, x), np.array([Const(0), Const(6), Const(1)]))
+    assert np.array_equal(to_const_polynomial(expr, x), np.array([Rat(0), Rat(6), Rat(1)]))
 
 
 def test_polynomial_division():

--- a/test_transforms.py
+++ b/test_transforms.py
@@ -8,13 +8,7 @@ Don't want to disconnect code structure from meaning too much altho it's easy to
 import numpy as np
 
 from src.simpy.expr import Rat
-from src.simpy.transforms import (
-    CompleteTheSquare,
-    Node,
-    PolynomialDivision,
-    PullConstant,
-    to_const_polynomial,
-)
+from src.simpy.transforms import CompleteTheSquare, Node, PolynomialDivision, PullConstant, to_const_polynomial
 from test_utils import assert_eq_strict, x
 
 

--- a/test_trig_simplify.py
+++ b/test_trig_simplify.py
@@ -47,7 +47,11 @@ def test_one_plus_tan_squared():
     simp = expr.simplify()
     assert_eq_strict(simp, 2 * sec(x + y) ** 2)
 
-    # expr = (2+y) + (2+y)*tan(x+y)** 2
+
+def test_one_minus_sin_squared_up_to_sum():
+    expr = 1 - sin(x) ** 2 + x
+    simp = expr.simplify()
+    assert_eq_strict(simp, x + cos(x) ** 2)
 
 
 """Other things

--- a/test_trig_simplify.py
+++ b/test_trig_simplify.py
@@ -1,21 +1,38 @@
+import pytest
+
 from src.simpy import *
+from src.simpy.transforms import ProductToSum, replace_factory
 from test_utils import *
 
 
+def test_simple():
+    assert_eq_value(1/sin(x), csc(x))
+    assert_eq_value(1/cos(x), sec(x))
+    assert_eq_value(tan(x), sin(x)/cos(x))
+
+
+"""Pythagorean simplifications"""
 def test_simplify_sin2x_plus_cos2x():
     expr = sin(x) ** 2 + cos(x) ** 2 + 3
     simplified = expr.simplify()
     assert_eq_strict(simplified, 4)
 
     # Test when sin^2(...) -> ... is more complicated than just 'x'
-    expr = sin(x - 2 * y) ** 2 + 3 + cos(x - 2 * y) ** 2 + y**2
+    expr = (sin(x - 2 * y) ** 2 + 3 + cos(x - 2 * y) ** 2 + y**2 + cos(x))
     simplified = expr.simplify()
-    assert_eq_strict(simplified, 4 + y**2)
+    assert_eq_strict(simplified, 4 + y**2 + cos(x))
 
     # Test when sin^2(...) and cos^2(...) share a common factor
     expr = 2*y*sin(x**3)**2 + 2*y*cos(x**3)**2
     simplified = expr.simplify()
     assert_eq_strict(simplified, 2*y)
+
+@pytest.mark.xfail
+def test_simplify_one_minus_sin_squared():
+    # this one used to fail when I only allowed the entire sum to be 1 - sin^2(...)
+    expr = sin(x)**2 - 5*cos(x)**2 + -1
+    simplified = expr.simplify()
+    assert_eq_strict(simplified, -4*cos(x))
 
 
 def test_one_plus_tan_squared():
@@ -28,3 +45,42 @@ def test_one_plus_tan_squared():
     assert_eq_strict(simp, 2 * sec(x+y) ** 2)
 
     # expr = (2+y) + (2+y)*tan(x+y)** 2
+
+"""Other things
+
+These didn't pass when I didn't have 'heuristic simplifications'
+"""
+
+def product_to_sum(expr):
+    return replace_factory(ProductToSum.condition, ProductToSum.perform)(expr)
+
+def test_pts():
+    # applying product-to-sum makes this simpler
+    e1 = 2*cos(x)*sin(2*x)/3 - sin(x)*cos(2*x)/3
+    e2 = sin(3*x)/6 + sin(x)/2
+    e1 = product_to_sum(e1)
+    e2 = product_to_sum(e2)
+    assert_eq_value(e1, e2)
+
+def test_sectan():
+    # need to replace sec^2(x) with tan^2(x) + 1
+    e1 = 1/(4*cos(x)**4) - 1/(3*cos(x)**6) + 1/(8*cos(x)**8)
+    e2 = tan(x)**6/6 + tan(x)**8/8
+    assert_eq_plusc(e1, e2)
+
+def test_csc_squared_deriv():
+    # need to write in terms of a common denominator
+    e1 = sin(x)/cos(x) - csc(x)/cos(x)
+    # this shit takes 2 rounds of simplification: first to -cos(x)/sin(x) then to -cot(x)
+    # make sure that both rounds are done in the simplify function.
+    e2 = -cot(x)
+    assert_eq_strict(e1.simplify(), e2)
+
+@pytest.mark.xfail
+def test_compound_angle():
+    # old solution of sin(x) ** 2 * cos(x) ** 3 simpy found when going 27 levels deep
+    # im guessing needs to compound angle/double angle this one.
+    e1 = sin(x)*cos(4*x)/120 + sin(x)*cos(2*x)/12 - cos(x)*sin(4*x)/30 - cos(x)*sin(2*x)/6 - sin(x)**3/6 + 3*sin(x)/8
+    e2 = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
+    assert_eq_value(e1, e2)
+

--- a/test_trig_simplify.py
+++ b/test_trig_simplify.py
@@ -6,81 +6,96 @@ from test_utils import *
 
 
 def test_simple():
-    assert_eq_value(1/sin(x), csc(x))
-    assert_eq_value(1/cos(x), sec(x))
-    assert_eq_value(tan(x), sin(x)/cos(x))
+    assert_eq_value(1 / sin(x), csc(x))
+    assert_eq_value(1 / cos(x), sec(x))
+    assert_eq_value(tan(x), sin(x) / cos(x))
 
 
 """Pythagorean simplifications"""
+
+
 def test_simplify_sin2x_plus_cos2x():
     expr = sin(x) ** 2 + cos(x) ** 2 + 3
     simplified = expr.simplify()
     assert_eq_strict(simplified, 4)
 
     # Test when sin^2(...) -> ... is more complicated than just 'x'
-    expr = (sin(x - 2 * y) ** 2 + 3 + cos(x - 2 * y) ** 2 + y**2 + cos(x))
+    expr = sin(x - 2 * y) ** 2 + 3 + cos(x - 2 * y) ** 2 + y**2 + cos(x)
     simplified = expr.simplify()
     assert_eq_strict(simplified, 4 + y**2 + cos(x))
 
     # Test when sin^2(...) and cos^2(...) share a common factor
-    expr = 2*y*sin(x**3)**2 + 2*y*cos(x**3)**2
+    expr = 2 * y * sin(x**3) ** 2 + 2 * y * cos(x**3) ** 2
     simplified = expr.simplify()
-    assert_eq_strict(simplified, 2*y)
+    assert_eq_strict(simplified, 2 * y)
+
 
 @pytest.mark.xfail
 def test_simplify_one_minus_sin_squared():
     # this one used to fail when I only allowed the entire sum to be 1 - sin^2(...)
-    expr = sin(x)**2 - 5*cos(x)**2 + -1
+    expr = sin(x) ** 2 - 5 * cos(x) ** 2 + -1
     simplified = expr.simplify()
-    assert_eq_strict(simplified, -4*cos(x))
+    assert_eq_strict(simplified, -4 * cos(x))
 
 
 def test_one_plus_tan_squared():
-    expr = 1 + tan(x+y)** 2
+    expr = 1 + tan(x + y) ** 2
     simp = expr.simplify()
-    assert_eq_strict(simp, sec(x+y)**2)
+    assert_eq_strict(simp, sec(x + y) ** 2)
 
-    expr = 2 + 2*tan(x+y)** 2
+    expr = 2 + 2 * tan(x + y) ** 2
     simp = expr.simplify()
-    assert_eq_strict(simp, 2 * sec(x+y) ** 2)
+    assert_eq_strict(simp, 2 * sec(x + y) ** 2)
 
     # expr = (2+y) + (2+y)*tan(x+y)** 2
+
 
 """Other things
 
 These didn't pass when I didn't have 'heuristic simplifications'
 """
 
+
 def product_to_sum(expr):
     return replace_factory(ProductToSum.condition, ProductToSum.perform)(expr)
 
+
 def test_pts():
     # applying product-to-sum makes this simpler
-    e1 = 2*cos(x)*sin(2*x)/3 - sin(x)*cos(2*x)/3
-    e2 = sin(3*x)/6 + sin(x)/2
+    e1 = 2 * cos(x) * sin(2 * x) / 3 - sin(x) * cos(2 * x) / 3
+    e2 = sin(3 * x) / 6 + sin(x) / 2
     e1 = product_to_sum(e1)
     e2 = product_to_sum(e2)
     assert_eq_value(e1, e2)
 
+
 def test_sectan():
     # need to replace sec^2(x) with tan^2(x) + 1
-    e1 = 1/(4*cos(x)**4) - 1/(3*cos(x)**6) + 1/(8*cos(x)**8)
-    e2 = tan(x)**6/6 + tan(x)**8/8
+    e1 = 1 / (4 * cos(x) ** 4) - 1 / (3 * cos(x) ** 6) + 1 / (8 * cos(x) ** 8)
+    e2 = tan(x) ** 6 / 6 + tan(x) ** 8 / 8
     assert_eq_plusc(e1, e2)
+
 
 def test_csc_squared_deriv():
     # need to write in terms of a common denominator
-    e1 = sin(x)/cos(x) - csc(x)/cos(x)
+    e1 = sin(x) / cos(x) - csc(x) / cos(x)
     # this shit takes 2 rounds of simplification: first to -cos(x)/sin(x) then to -cot(x)
     # make sure that both rounds are done in the simplify function.
     e2 = -cot(x)
     assert_eq_strict(e1.simplify(), e2)
 
+
 @pytest.mark.xfail
 def test_compound_angle():
     # old solution of sin(x) ** 2 * cos(x) ** 3 simpy found when going 27 levels deep
     # im guessing needs to compound angle/double angle this one.
-    e1 = sin(x)*cos(4*x)/120 + sin(x)*cos(2*x)/12 - cos(x)*sin(4*x)/30 - cos(x)*sin(2*x)/6 - sin(x)**3/6 + 3*sin(x)/8
+    e1 = (
+        sin(x) * cos(4 * x) / 120
+        + sin(x) * cos(2 * x) / 12
+        - cos(x) * sin(4 * x) / 30
+        - cos(x) * sin(2 * x) / 6
+        - sin(x) ** 3 / 6
+        + 3 * sin(x) / 8
+    )
     e2 = sin(x) ** 3 / 3 - sin(x) ** 5 / 5
     assert_eq_value(e1, e2)
-

--- a/test_utils.py
+++ b/test_utils.py
@@ -8,6 +8,7 @@ x, y = symbols("x y")
 @cast
 def assert_integral(integrand: Expr, expected: Expr, var: Optional[Symbol] = None):
     assert_eq_plusc(integrate(integrand, var), expected)
+    # assert_eq_value(diff(expected, var), integrand) # this might be nice; idk. catch some potential diff errors.
 
 @cast
 def assert_definite_integral(integrand: Expr, bounds: tuple, expected: Expr):

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,7 +1,10 @@
-from typing import Optional
+from typing import Optional, Tuple, Type
 
-from src.simpy.expr import Expr, Symbol, cast, debug_repr, symbols
+from src.simpy.expr import (Const, Expr, Power, SingleFunc, Symbol,
+                            TrigFunction, cast, cos, debug_repr, sec, symbols,
+                            tan)
 from src.simpy.integration import integrate
+from src.simpy.regex import replace_class, replace_factory
 
 x, y = symbols("x y")
 
@@ -19,6 +22,7 @@ def assert_eq_plusc(a: Expr, b: Expr, *vars):
     """Assert a and b are equal up to a constant, relative to vars.
     If no vars are given, then 
     """
+    a, b = sectan(a, b)
     diff = a - b
     diff = diff.expand().simplify() if diff.expandable() else diff.simplify()
     if not vars:
@@ -26,22 +30,73 @@ def assert_eq_plusc(a: Expr, b: Expr, *vars):
     else:
         assert all(var not in diff.symbols() for var in vars), f"diff = {diff}"
         
-@cast
-def assert_eq_value(a: Expr, b: Expr):
-    """Tests that the values of a & b are the same in spirit, regardless of how they are represented with the Expr data structures.
+def is_cls_squared(expr, cls) -> bool:
+    return isinstance(expr, Power) and isinstance(expr.base, cls) and isinstance(expr.exponent, Const) and expr.exponent % 2 == 0
+
+def only_contains_class_squared(expr: Expr, cls: Type[SingleFunc]) -> bool:
+    """Return if it's a function of cls squared.
+    Which means that expr has to contain cls and all instances of cls have to be squared.
     """
+    if not expr.has(cls):
+        return False
+
+    def _func(e):
+        if isinstance(e, cls):
+            return False
+        if is_cls_squared(e, cls):
+            return True
+        return all(_func(c) for c in e.children())
+
+    return _func(expr)
+
+def sectan(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
+    if not a.has(TrigFunction) or not b.has(TrigFunction):
+        return a, b
+
+    def _sectan(a, b):
+        # a is sec and b is tan
+        # convert a to b
+        condition = lambda x: is_cls_squared(x, sec)
+        def perform(e: Power):
+            n = e.exponent
+            return (1 + tan(e.base.inner) ** 2) ** (n / 2)
+        
+        a = replace_factory(condition, perform)(a)
+        a = a.expand() if a.expandable() else a
+        return a, b
+
+    a = replace_class(a, [cos], [lambda x: 1 / sec(x)])
+    b = replace_class(b, [cos], [lambda x: 1 / sec(x)])
+    if only_contains_class_squared(a, sec) and only_contains_class_squared(b, tan):
+        return _sectan(a, b)
+
+    if only_contains_class_squared(b, sec) and only_contains_class_squared(a, tan):
+        return _sectan(b, a)
+    
+    return a, b
+
+
+def _eq_value(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
+    a, b = sectan(a, b)
     a = a.simplify()
     b = b.simplify()
     if a.expandable():
         a = a.expand()
     if b.expandable():
         b = b.expand()
-    assert repr(a) == repr(b), f"a != b, {a} != {b}"
+    return a, b
+
+@cast
+def assert_eq_value(a: Expr, b: Expr):
+    """Tests that the values of a & b are the same in spirit, regardless of how they are represented with the Expr data structures.
+    """
+    a, b = _eq_value(a, b)
+    assert a == b, f"a != b, {a} != {b}"
 
 @cast
 def assert_eq_strict(a: Expr, b: Expr):
     """Tests that the structure of a and b exprs are the same, not just their values or reprs.
-    // This does the same thing as assert a == b I believe.
+    // This does the same thing as assert debug_repr(a) == debug_repr(b) I believe.
     """
     assert a == b, f"STRICT: {a} != {b}, \n\tDebug repr: {debug_repr(a)} != {debug_repr(b)}"
 

--- a/test_utils.py
+++ b/test_utils.py
@@ -6,8 +6,8 @@ from src.simpy.integration import integrate
 x, y = symbols("x y")
 
 @cast
-def assert_integral(integrand: Expr, expected: Expr, var: Optional[Symbol] = None):
-    assert_eq_plusc(integrate(integrand, var), expected)
+def assert_integral(integrand: Expr, expected: Expr, var: Optional[Symbol] = None, **kwargs):
+    assert_eq_plusc(integrate(integrand, var, **kwargs), expected)
     # assert_eq_value(diff(expected, var), integrand) # this might be nice; idk. catch some potential diff errors.
 
 @cast

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,25 +1,40 @@
 from typing import Optional, Tuple, Type
 
-from src.simpy.expr import (Expr, Power, Rat, SingleFunc, Symbol, TrigFunction,
-                            cast, cos, debug_repr, sec, symbols, tan)
+from src.simpy.expr import (
+    Expr,
+    Power,
+    Rat,
+    SingleFunc,
+    Symbol,
+    TrigFunction,
+    cast,
+    cos,
+    debug_repr,
+    sec,
+    symbols,
+    tan,
+)
 from src.simpy.integration import integrate
 from src.simpy.regex import replace_class, replace_factory
 
 x, y = symbols("x y")
+
 
 @cast
 def assert_integral(integrand: Expr, expected: Expr, var: Optional[Symbol] = None, **kwargs):
     assert_eq_plusc(integrate(integrand, var, **kwargs), expected)
     # assert_eq_value(diff(expected, var), integrand) # this might be nice; idk. catch some potential diff errors.
 
+
 @cast
 def assert_definite_integral(integrand: Expr, bounds: tuple, expected: Expr):
     assert_eq_strict(integrate(integrand, bounds), expected)
 
+
 @cast
 def assert_eq_plusc(a: Expr, b: Expr, *vars):
     """Assert a and b are equal up to a constant, relative to vars.
-    If no vars are given, then 
+    If no vars are given, then
     """
     a, b = sectan(a, b)
     diff = a - b
@@ -28,9 +43,16 @@ def assert_eq_plusc(a: Expr, b: Expr, *vars):
         assert len(diff.symbols()) == 0, f"diff = {diff}"
     else:
         assert all(var not in diff.symbols() for var in vars), f"diff = {diff}"
-        
+
+
 def is_cls_squared(expr, cls) -> bool:
-    return isinstance(expr, Power) and isinstance(expr.base, cls) and isinstance(expr.exponent, Rat) and expr.exponent % 2 == 0
+    return (
+        isinstance(expr, Power)
+        and isinstance(expr.base, cls)
+        and isinstance(expr.exponent, Rat)
+        and expr.exponent % 2 == 0
+    )
+
 
 def only_contains_class_squared(expr: Expr, cls: Type[SingleFunc]) -> bool:
     """Return if it's a function of cls squared.
@@ -48,6 +70,7 @@ def only_contains_class_squared(expr: Expr, cls: Type[SingleFunc]) -> bool:
 
     return _func(expr)
 
+
 def sectan(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
     if not a.has(TrigFunction) or not b.has(TrigFunction):
         return a, b
@@ -56,10 +79,11 @@ def sectan(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
         # a is sec and b is tan
         # convert a to b
         condition = lambda x: is_cls_squared(x, sec)
+
         def perform(e: Power):
             n = e.exponent
             return (1 + tan(e.base.inner) ** 2) ** (n / 2)
-        
+
         a = replace_factory(condition, perform)(a)
         a = a.expand() if a.expandable() else a
         return a, b
@@ -71,7 +95,7 @@ def sectan(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
 
     if only_contains_class_squared(b, sec) and only_contains_class_squared(a, tan):
         return _sectan(b, a)
-    
+
     return a, b
 
 
@@ -85,12 +109,13 @@ def _eq_value(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
         b = b.expand()
     return a, b
 
+
 @cast
 def assert_eq_value(a: Expr, b: Expr):
-    """Tests that the values of a & b are the same in spirit, regardless of how they are represented with the Expr data structures.
-    """
+    """Tests that the values of a & b are the same in spirit, regardless of how they are represented with the Expr data structures."""
     a, b = _eq_value(a, b)
     assert a == b, f"a != b, {a} != {b}"
+
 
 @cast
 def assert_eq_strict(a: Expr, b: Expr):
@@ -101,8 +126,7 @@ def assert_eq_strict(a: Expr, b: Expr):
 
 
 def unhashable_set_eq(a: list, b: list) -> bool:
-    """Does equivalent of set(a) == set(b) but for lists containing unhashable types
-    """
+    """Does equivalent of set(a) == set(b) but for lists containing unhashable types"""
     for el in a:
         if el not in b:
             return False

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,8 +1,7 @@
 from typing import Optional, Tuple, Type
 
-from src.simpy.expr import (Const, Expr, Power, SingleFunc, Symbol,
-                            TrigFunction, cast, cos, debug_repr, sec, symbols,
-                            tan)
+from src.simpy.expr import (Expr, Power, Rat, SingleFunc, Symbol, TrigFunction,
+                            cast, cos, debug_repr, sec, symbols, tan)
 from src.simpy.integration import integrate
 from src.simpy.regex import replace_class, replace_factory
 
@@ -31,7 +30,7 @@ def assert_eq_plusc(a: Expr, b: Expr, *vars):
         assert all(var not in diff.symbols() for var in vars), f"diff = {diff}"
         
 def is_cls_squared(expr, cls) -> bool:
-    return isinstance(expr, Power) and isinstance(expr.base, cls) and isinstance(expr.exponent, Const) and expr.exponent % 2 == 0
+    return isinstance(expr, Power) and isinstance(expr.base, cls) and isinstance(expr.exponent, Rat) and expr.exponent % 2 == 0
 
 def only_contains_class_squared(expr: Expr, cls: Type[SingleFunc]) -> bool:
     """Return if it's a function of cls squared.

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,19 +1,6 @@
 from typing import Optional, Tuple, Type
 
-from src.simpy.expr import (
-    Expr,
-    Power,
-    Rat,
-    SingleFunc,
-    Symbol,
-    TrigFunction,
-    cast,
-    cos,
-    debug_repr,
-    sec,
-    symbols,
-    tan,
-)
+from src.simpy.expr import Expr, Power, Rat, SingleFunc, Symbol, TrigFunction, cast, cos, debug_repr, sec, symbols, tan
 from src.simpy.integration import integrate
 from src.simpy.regex import replace_class, replace_factory
 
@@ -72,6 +59,7 @@ def only_contains_class_squared(expr: Expr, cls: Type[SingleFunc]) -> bool:
 
 
 def sectan(a: Expr, b: Expr) -> Tuple[Expr, Expr]:
+    # futureTODO: his (& similar things) should be done in simplify during subtractions.
     if not a.has(TrigFunction) or not b.has(TrigFunction):
         return a, b
 


### PR DESCRIPTION
# what is changed:
- [x] massively revamp simplification
- [x] introduction of infinity
- [x] RewritePythag transform (fixes #21)
- [x] Rewrite tree transversing to be less stuck -> this led to massive speedups 

### todo:
- [x] make the csc^2(x) test work. requires letting 1 - sin^2(x) + any
- [x] performance improvements (later PR probs) (Fixes #39)
- [ ] #35 (maybe later PR)

# babble
2.30 vs 1.69

integrating takes significantly longer on this branch than on main?
maybe depth first was better idk

ok tan^4(x) fails with depth first.

breadth first: 5.56s including 2s timeout for failed one. 3.56
depth first: 4.94s. 3.34s without tan.
ok without tan it's like close enough i guess.

// things taking longer in general is due to probably just the addition of a transform and now that's often checked ?? 


ok once i do this: 
![image](https://github.com/laurgao/simpy/assets/47482178/877f248d-be78-4258-a1d1-31408d7b1aa3)

tan^4(x) is extremely fast. it gets caught much faster.
but without that, our breadth first doesn't work rlly as intended. without that, nesting(thatexpr) = 5 but we go all the way to exprs of nestings of like 8 or 9 before turning back? why?

interestingly, adding that line makes all the nontan things combined .2s slower out of 5.5s

also, this much shit shouldn't take 2 seconds lmfao sth is inefficient abt my recursion probs.
